### PR TITLE
build!: migrate the test suite to node:test and require Node.js >= 22.12.0

### DIFF
--- a/.changeset/require-node-22.md
+++ b/.changeset/require-node-22.md
@@ -1,0 +1,5 @@
+---
+"lint-webpack-plugin": major
+---
+
+Dropped Node.js 20, which is end-of-life. The minimum is now Node.js `>= 22.12.0`.

--- a/.cspell.json
+++ b/.cspell.json
@@ -39,6 +39,7 @@
     "CHANGELOG.md",
     "coverage",
     "dist/**",
+    "lcov.info",
     "node_modules",
     "package-lock.json",
     "package.json"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
         eslint-version: [9.x, 10.x]
         webpack-version: [latest]
 
@@ -89,11 +89,12 @@ jobs:
         run: npm i eslint@${{ matrix.eslint-version }}
 
       - name: Run tests for webpack version ${{ matrix.webpack-version }}
-        run: npm run test:coverage -- --ci
+        run: npm run test:coverage
 
       - name: Submit coverage data to codecov
         uses: codecov/codecov-action@v6
         with:
+          files: ./lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-linters:
@@ -129,4 +130,4 @@ jobs:
         run: npm i stylelint@${{ matrix.stylelint-version }}
 
       - name: Run tests
-        run: npm run test:only -- --ci
+        run: npm run test:only

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -55,19 +55,18 @@ jobs:
         run: npx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
   test:
-    name: Test - ${{ matrix.os }} - Node v${{ matrix.node-version }}, Webpack ${{ matrix.webpack-version }}, Eslint ${{ matrix.eslint-version }}
+    name: Test - ${{ matrix.os }} - Node v${{ matrix.node-version }}, Webpack ${{ matrix.webpack-version }}
 
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [22.x, 24.x]
-        eslint-version: [9.x, 10.x]
         webpack-version: [latest]
 
     runs-on: ${{ matrix.os }}
 
     concurrency:
-      group: test-${{ matrix.os }}-v${{ matrix.node-version }}-${{ matrix.eslint-version }}-${{ matrix.webpack-version }}-${{ github.ref }}
+      group: test-${{ matrix.os }}-v${{ matrix.node-version }}-${{ matrix.webpack-version }}-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -84,9 +83,6 @@ jobs:
 
       - name: Install webpack ${{ matrix.webpack-version }}
         run: npm i webpack@${{ matrix.webpack-version }}
-
-      - name: Install eslint ${{ matrix.eslint-version }}
-        run: npm i eslint@${{ matrix.eslint-version }}
 
       - name: Run tests for webpack version ${{ matrix.webpack-version }}
         run: npm run test:coverage

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 
 /coverage
 /dist
+/lcov.info
 /local
 /reports
 /node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 /coverage
 /dist
+/lcov.info
 /node_modules
 /test/fixtures
 /test/outputs

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 # lint-webpack-plugin
 
-> This plugin only supports webpack 5.
+> This plugin only supports webpack 5 and Node.js `>= 22.12.0`.
 
 This plugin runs linters and diagnostic tools over your sources during the webpack build and reports what they find as webpack errors and warnings.
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,7 +3,7 @@ const MIN_BABEL_VERSION = 7;
 export default (api) => {
   api.assertVersion(MIN_BABEL_VERSION);
 
-  // Only the CommonJS build rewrites modules; the ESM build and jest keep them
+  // Only the CommonJS build rewrites modules; the ESM build keeps them
   const toCommonJs = api.env() === "cjs";
 
   return {
@@ -12,7 +12,7 @@ export default (api) => {
         "@babel/preset-env",
         {
           targets: {
-            node: "20.9.0",
+            node: "22.12.0",
           },
           modules: toCommonJs ? "commonjs" : false,
           // Keep `import()` dynamic, a `stylelintPath` is only known at runtime

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,4 +13,23 @@ export default defineConfig([
   {
     extends: [configs["recommended-dirty"]],
   },
+  {
+    // `eslint-config-webpack` relaxes these for tests only when jest is a
+    // dependency, and the suite runs on `node:test` instead.
+    name: "lint-webpack-plugin/tests",
+    files: ["test/**/*.js"],
+    rules: {
+      camelcase: "off",
+      "id-length": "off",
+      "jsdoc/require-jsdoc": "off",
+      "n/no-unpublished-import": "off",
+      "n/no-unpublished-require": "off",
+      "n/no-unsupported-features/es-builtins": "off",
+      "n/no-unsupported-features/es-syntax": "off",
+      "n/no-unsupported-features/node-builtins": "off",
+      "no-console": "off",
+      "no-control-regex": "off",
+      "no-eval": "off",
+    },
+  },
 ]);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,0 @@
-export default {
-  collectCoverage: true,
-  collectCoverageFrom: ["src/**/*"],
-  testEnvironment: "node",
-  testTimeout: 60000,
-  transformIgnorePatterns: ["node_modules/(?!(arrify)/)"],
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,6 @@
         "@changesets/get-github-info": "^0.8.0",
         "@commitlint/cli": "^21.2.2",
         "@commitlint/config-conventional": "^21.2.2",
-        "@jest/globals": "^30.5.1",
-        "@types/fs-extra": "^11.0.4",
         "@types/micromatch": "^4.0.10",
         "@types/node": "^26.4.1",
         "@types/normalize-path": "^3.0.2",
@@ -38,10 +36,8 @@
         "eslint": "^10.10.0",
         "eslint-config-webpack": "^4.9.6",
         "file-loader": "^6.2.0",
-        "fs-extra": "^11.4.0",
         "globals": "^17.12.0",
         "husky": "^9.1.7",
-        "jest": "^30.5.1",
         "lint-staged": "^17.5.0",
         "npm-run-all": "^4.1.5",
         "postcss-scss": "^4.0.9",
@@ -51,7 +47,7 @@
         "webpack": "^5.110.3"
       },
       "engines": {
-        "node": ">= 20.9.0"
+        "node": ">= 22.12.0"
       },
       "funding": {
         "type": "opencollective",
@@ -653,6 +649,8 @@
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -666,6 +664,8 @@
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -679,6 +679,8 @@
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
       },
@@ -692,6 +694,8 @@
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -740,6 +744,8 @@
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -753,6 +759,8 @@
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -766,6 +774,8 @@
       "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -782,6 +792,8 @@
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -795,6 +807,8 @@
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -808,6 +822,8 @@
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -821,6 +837,8 @@
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -834,6 +852,8 @@
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -847,6 +867,8 @@
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
       },
@@ -860,6 +882,8 @@
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -876,6 +900,8 @@
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -892,6 +918,8 @@
       "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
@@ -1929,7 +1957,9 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@cacheable/memory": {
       "version": "2.2.0",
@@ -3471,6 +3501,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -3483,6 +3514,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3494,6 +3526,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3789,6 +3822,8 @@
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -3807,6 +3842,8 @@
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3819,7 +3856,9 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
@@ -3827,6 +3866,8 @@
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -3845,6 +3886,8 @@
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -3863,6 +3906,8 @@
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
@@ -3880,6 +3925,8 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -3890,6 +3937,8 @@
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -3904,6 +3953,8 @@
       "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3918,6 +3969,8 @@
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -3931,6 +3984,8 @@
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -3947,6 +4002,8 @@
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -3960,6 +4017,8 @@
       "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3970,6 +4029,8 @@
       "integrity": "sha512-u5Ncuc+gXVUwjNMFQOnphHo2Qx2DxyC8Dvpmf4HCx4y0kvSkRRNiQYRixrvOP4V7y52JcSuNxqochCt0PpdHVg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.5.1",
         "@types/node": "*",
@@ -3988,6 +4049,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4004,6 +4067,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4021,6 +4086,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4033,7 +4100,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@jest/console/node_modules/slash": {
       "version": "3.0.0",
@@ -4041,6 +4110,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4051,6 +4122,8 @@
       "integrity": "sha512-BL9g6CJUUhIbdoAflz/Va658erSSXUIvU8XUYiWNTbZljJjZ5yaC9EJ9/dQ19rpbYV3ZOK4sBACqhPaTyhoUIA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/console": "30.5.1",
         "@jest/pattern": "30.5.0",
@@ -4099,6 +4172,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4115,6 +4190,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4132,6 +4209,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4144,7 +4223,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@jest/core/node_modules/slash": {
       "version": "3.0.0",
@@ -4152,6 +4233,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4162,6 +4245,8 @@
       "integrity": "sha512-OsqBjHXCn8cadasoAZBP6nWYvMsRhpMzGXTpxJ5aO04NlbdhIz+FVe3q49l0AwVhsz/cEmIpBes6gAFl1/dWQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -4172,6 +4257,8 @@
       "integrity": "sha512-eYJAkOsrpwDXPcoLNEG6lN9Zo3Cy35pxnVQD74vyIfsi/Q8wB/lZFsEjU4wrecOgT4ZviQDZaX/cFIJyMdMxTw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/fake-timers": "30.5.1",
         "@jest/types": "30.5.1",
@@ -4188,6 +4275,8 @@
       "integrity": "sha512-uOGd40P/COyUp9xHf5jeGiGJC2/ANg+2+Tk9/xN5/LxmlY/r/gxsPrx3DTEtaRZsLAX4wgNSLEDELZ5bmVs2bA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "expect": "30.5.1",
         "jest-snapshot": "30.5.1"
@@ -4202,6 +4291,8 @@
       "integrity": "sha512-WcRWhHQdTMRDpyWKZ/6MINBmovI7zeD+bL8wFjCncRV3NQOwKy1X45IfyblfHR4k/XciIlNEdFL9QjFO+HNKOg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.5.0"
       },
@@ -4215,6 +4306,8 @@
       "integrity": "sha512-rEkV6YzpBXo/L9cnj2ibyuYZuyGiNWaPUsyCu3HYJbqCV4jnEiKmf7hId20z8eKjZ0JQ9jtIYKxRSmYB/OYSsA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.5.1",
         "@sinonjs/fake-timers": "^15.4.0",
@@ -4233,6 +4326,8 @@
       "integrity": "sha512-9/2VUPitAjmBzbvDvqrxmvB7BzWsBW0WmkkojX1ODuxX1NLGxx9gfaZpHB0z8DtJ9uhGNmZG/VXBhf8uO0OV8Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -4243,6 +4338,8 @@
       "integrity": "sha512-VhqvQ251XIC7pk46YymI3HCeBLOdvriDw9zibekodAHEwoVvbVVgpU5H13GvmyOAzxtZCfsm1uvzqkaqJf2I+g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.5.1",
         "@jest/expect": "30.5.1",
@@ -4272,7 +4369,9 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@jest/react-is-19": {
       "name": "react-is",
@@ -4280,7 +4379,9 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
       "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@jest/reporters": {
       "version": "30.5.1",
@@ -4288,6 +4389,8 @@
       "integrity": "sha512-RbUXIfv85KxitJn4l3MpAoMilkvXe2QCO5lXxHWftywo/VdZ5vkEoHRDgphcxP6qmoIkUaN8/UZj6NhdkIFdJg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@jest/console": "30.5.1",
@@ -4331,6 +4434,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4347,6 +4452,8 @@
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -4357,6 +4464,8 @@
       "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -4370,6 +4479,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4387,6 +4498,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4399,7 +4512,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@jest/reporters/node_modules/glob": {
       "version": "13.0.6",
@@ -4407,6 +4522,8 @@
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
@@ -4425,6 +4542,8 @@
       "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.8"
       },
@@ -4441,6 +4560,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4463,6 +4584,8 @@
       "integrity": "sha512-V3wnxNtiVmw5PPVg433Cn3VdXnsOeu/ofLw3KC04Bn2y1wIlU5kozXQn48rhrgj/02LrCVtntTEF1yBha0XSUw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.5.1",
         "chalk": "^4.1.2",
@@ -4479,6 +4602,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4495,6 +4620,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4512,6 +4639,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4524,7 +4653,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@jest/source-map": {
       "version": "30.5.0",
@@ -4532,6 +4663,8 @@
       "integrity": "sha512-xWpTJP9D0bDFGbPGT8XuWSwwha/iHADyyKzUnMx4UbdgnHugxrDaQFO4RZ8x4ZsFzRP6pNii8uvlgKCDxCIuDg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "callsites": "^3.1.0",
@@ -4548,6 +4681,8 @@
       "integrity": "sha512-A/1S6ZBdpic50E0pxLgvaB9XNPL4k7AksmG69OO2oiotxciWZwHkbOec+qbIi+uUtIIByOVlXJUl97oZUsz+Jw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/console": "30.5.1",
         "@jest/types": "30.5.1",
@@ -4564,6 +4699,8 @@
       "integrity": "sha512-SHcPnrjdVRYJv6y6l4JUTy4Jccu7zmO6BmiOfOA34UiVBto22s19WiDC0A/2qfM7MWB/qdcoqfSIRMitpjTT4A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/test-result": "30.5.1",
         "graceful-fs": "^4.2.11",
@@ -4580,6 +4717,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4590,6 +4729,8 @@
       "integrity": "sha512-EDnDhn0jleU9ZhpVoA4gvqw+Ev0iw/r5upNT2b79RiwiaTiYAMMhvNJP3lmocjIe5J2ZkoNr0B3K/J6O5GIm4Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.5.1",
@@ -4616,6 +4757,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4632,6 +4775,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4649,6 +4794,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4661,7 +4808,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@jest/transform/node_modules/slash": {
       "version": "3.0.0",
@@ -4669,6 +4818,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4874,6 +5025,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
@@ -4939,6 +5091,8 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -4980,6 +5134,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5001,6 +5156,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5022,6 +5178,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5043,6 +5200,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5064,6 +5222,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5085,6 +5244,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5106,6 +5266,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5127,6 +5288,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5148,6 +5310,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5169,6 +5332,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5190,6 +5354,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5211,6 +5376,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5226,6 +5392,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5330,6 +5497,8 @@
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -5340,6 +5509,8 @@
       "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
@@ -5372,6 +5543,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -5382,6 +5554,8 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -5396,6 +5570,8 @@
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -5406,6 +5582,8 @@
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -5417,6 +5595,8 @@
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
@@ -5460,17 +5640,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
-    },
-    "node_modules/@types/fs-extra": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
-      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/hast": {
       "version": "3.0.5",
@@ -5518,16 +5687,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/jsonfile": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
-      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/katex": {
       "version": "0.16.8",
@@ -5584,7 +5743,9 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -5689,7 +5850,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.12.2",
@@ -5703,7 +5865,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.12.2",
@@ -5717,7 +5880,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.12.2",
@@ -5731,7 +5895,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.12.2",
@@ -5745,7 +5910,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.12.2",
@@ -5759,7 +5925,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.12.2",
@@ -5773,7 +5940,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.12.2",
@@ -5787,7 +5955,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.12.2",
@@ -5801,7 +5970,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
       "version": "1.12.2",
@@ -5815,7 +5985,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
       "version": "1.12.2",
@@ -5829,7 +6000,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.12.2",
@@ -5843,7 +6015,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.12.2",
@@ -5857,7 +6030,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.12.2",
@@ -5871,7 +6045,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.12.2",
@@ -5885,7 +6060,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.12.2",
@@ -5899,7 +6075,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.12.2",
@@ -5913,7 +6090,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-openharmony-arm64": {
       "version": "1.12.2",
@@ -5927,7 +6105,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.12.2",
@@ -5939,6 +6118,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -5960,7 +6140,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.12.2",
@@ -5974,7 +6155,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.12.2",
@@ -5988,7 +6170,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -6239,6 +6422,8 @@
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -6281,6 +6466,7 @@
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -6295,6 +6481,7 @@
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -6550,6 +6737,8 @@
       "integrity": "sha512-ge1xUVZS91ml09YRMgRGgeKJ4YJpcOiuwteAxFBYLugQyp7cRw+hHej6Ho0vPjvLrjq60bb7JPHH9LAMA1/krA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/transform": "30.5.1",
         "@types/babel__core": "^7.20.5",
@@ -6572,6 +6761,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -6588,6 +6779,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -6605,6 +6798,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -6617,7 +6812,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/babel-jest/node_modules/slash": {
       "version": "3.0.0",
@@ -6625,6 +6822,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6635,6 +6834,8 @@
       "integrity": "sha512-18wCskrN3DgbuBmp1gr7LBGT8xdz5xhQQqFvFhVxbkl8VBCrMKQ2YtqBWtUal1Zrc1HTuX0011+Brjw78TCFkg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "workspaces": [
         "test/babel-8"
       ],
@@ -6655,6 +6856,8 @@
       "integrity": "sha512-gtGo1B+u14jrZQv6TdSWIWkTqclboo7Qn+dFAGUOIuXLFuJKAdg3U5MIWzZnW4vfUb4dX9skmAMiby86e/SF4A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/babel__core": "^7.20.5"
       },
@@ -6724,6 +6927,8 @@
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -6751,6 +6956,8 @@
       "integrity": "sha512-ZGPn5ClP4lBDpuOK8W1yQIOy359HmbnZv3suucAlIe+SEE9yDsxV4S2PjSbH2Vc97U+WmzYD7vw3kr8NsQ/i6w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "babel-plugin-jest-hoist": "30.5.0",
         "babel-preset-current-node-syntax": "^1.2.0"
@@ -6869,6 +7076,8 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-int64": "^0.4.0"
       }
@@ -6983,6 +7192,8 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7061,6 +7272,8 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7122,7 +7335,9 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
       "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/clean-regexp": {
       "version": "1.0.0",
@@ -7153,6 +7368,8 @@
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -7168,6 +7385,8 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7178,6 +7397,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -7194,6 +7415,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -7206,7 +7429,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -7214,6 +7439,8 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7224,6 +7451,8 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7239,6 +7468,8 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -7252,6 +7483,8 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7270,6 +7503,8 @@
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -7280,7 +7515,9 @@
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
       "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -7877,6 +8114,8 @@
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -7899,6 +8138,8 @@
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8082,6 +8323,8 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8092,6 +8335,8 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8155,7 +8400,9 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.422",
@@ -8170,6 +8417,8 @@
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9712,6 +9961,8 @@
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.0",
@@ -9736,6 +9987,8 @@
       "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -9746,6 +9999,8 @@
       "integrity": "sha512-m8YrYgvKe9+9gEnWEuKz+qCGfHqkrff7PPfyDnOFkjsfYRKqiYyOxDFMFieCGAuhtk/VNm63tvNgKZVzVy+Hvg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/expect-utils": "30.5.1",
         "@jest/get-type": "30.5.0",
@@ -9905,6 +10160,8 @@
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bser": "2.1.1"
       }
@@ -10094,6 +10351,8 @@
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -10111,6 +10370,8 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -10125,21 +10386,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
-      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/fs-readdir-recursive": {
@@ -10299,6 +10545,8 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -10323,6 +10571,8 @@
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10728,7 +10978,9 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/html-tags": {
       "version": "5.1.0",
@@ -10759,6 +11011,8 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.17.0"
       }
@@ -10834,6 +11088,8 @@
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "pkg-dir": "^4.2.0",
         "resolve-cwd": "^3.0.0"
@@ -11145,6 +11401,8 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -11339,6 +11597,8 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -11463,6 +11723,8 @@
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11473,6 +11735,8 @@
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -11490,6 +11754,8 @@
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11503,6 +11769,8 @@
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^4.0.0",
@@ -11518,6 +11786,8 @@
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       },
@@ -11534,6 +11804,8 @@
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11547,6 +11819,8 @@
       "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.23",
         "debug": "^4.1.1",
@@ -11562,6 +11836,8 @@
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
@@ -11594,6 +11870,8 @@
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -11610,6 +11888,8 @@
       "integrity": "sha512-3qrR8+ZXFnn7y0H2yjWQNkGGBLBY4zTRoTMAq9zJcgwLLtlyonfsCLviIXK9xuE2KgIyM+M36AFcoK2DgFR36w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.5.1",
         "@jest/types": "30.5.1",
@@ -11637,6 +11917,8 @@
       "integrity": "sha512-0+bvMM/ENhDI29Z8q1r4HxiDIi4G5tnBmSw4esfPQoj9q8Nik7KIyuxHkTVnnniJQf05SxpGaKDQ+4h28ynGPg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "execa": "^5.1.1",
         "jest-util": "30.5.1",
@@ -11652,6 +11934,8 @@
       "integrity": "sha512-NgliezXQ6yznqR4W5Gqw++0cZSbBZlF0NknNIAE5VmSJKWOtmWJmWnBq3TSkUOVBTPrT7FGGhVdA8DLWnxo2Sw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.5.1",
         "@jest/expect": "30.5.1",
@@ -11684,6 +11968,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -11700,6 +11986,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -11717,6 +12005,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -11729,7 +12019,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-circus/node_modules/slash": {
       "version": "3.0.0",
@@ -11737,6 +12029,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11747,6 +12041,8 @@
       "integrity": "sha512-uwNYepWgaNBCplm42fCIUZTf/tIEHIy5AYvx7eL1BrwIgyjPt+2poouR23UO2yopIP+kV8oZFHfv+l4pg/8prQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.5.1",
         "@jest/test-result": "30.5.1",
@@ -11780,6 +12076,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -11796,6 +12094,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -11813,6 +12113,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -11825,7 +12127,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-config": {
       "version": "30.5.1",
@@ -11833,6 +12137,8 @@
       "integrity": "sha512-L8PKM2X/ngG8PxfLMqglKGZjylPgw84bVPUlMY9W/o76TnLqPWrmQgsaT0HrheGdRtpGE5FbmREA0Kvb+Qx5gQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.5.0",
@@ -11884,6 +12190,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -11900,6 +12208,8 @@
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -11910,6 +12220,8 @@
       "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -11923,6 +12235,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -11940,6 +12254,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -11952,7 +12268,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-config/node_modules/glob": {
       "version": "13.0.6",
@@ -11960,6 +12278,8 @@
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
@@ -11978,6 +12298,8 @@
       "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.8"
       },
@@ -11994,6 +12316,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12004,6 +12328,8 @@
       "integrity": "sha512-e3cNNMpv8Kh20MjjphTXs+3Vz7DQyLM1nft7KJhnh46atFhjVJRa+0Hq0beywuwsACtMQUBihQkFl8zxb7gt1Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.5.0",
         "@jest/get-type": "30.5.0",
@@ -12020,6 +12346,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12036,6 +12364,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12053,6 +12383,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12065,7 +12397,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-docblock": {
       "version": "30.5.0",
@@ -12073,6 +12407,8 @@
       "integrity": "sha512-NwDqcxtoZi33RhuW+zJS/RVA3rmheQ8BnwpYZuc/Eruaz6seQb7+aoCeDZu/3X7W2XmD8DbSo9Pn72DbKsBFYw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-newline": "^3.1.0"
       },
@@ -12086,6 +12422,8 @@
       "integrity": "sha512-S1af0TU4v1EZ/AUlkFs/sxf/5KGsbAT9kRgdyoMX/x72y7C8ZEgETE5o1TPnbKRnrbprc5FR/moYLfdRmqEjsQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.5.0",
         "@jest/types": "30.5.1",
@@ -12103,6 +12441,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12119,6 +12459,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12136,6 +12478,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12148,7 +12492,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-environment-node": {
       "version": "30.5.1",
@@ -12156,6 +12502,8 @@
       "integrity": "sha512-LrPj3sPMjsQoOB3jrb8p/sa+XkSFNKo60TTsyc+EB2kxQJHgbwElpXnx1yX25fdFn5958FIObRtcLSHyV8VIAw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.5.1",
         "@jest/fake-timers": "30.5.1",
@@ -12175,6 +12523,8 @@
       "integrity": "sha512-VIFgt67jW480YDxKfEv9IYQKrFpYt7bOCMn3VsnjK7AK9qo7p6acpnA1DHwsVOULE3dTaYew/6JaTD/d0VDHoQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.5.1",
         "@parcel/watcher": "^2.6.0",
@@ -12198,6 +12548,8 @@
       "integrity": "sha512-gt4GT2aWgEoCNTcBe4rqS74xTIUJxi+UD9SNSu9aOk5LmTEd6fS5KSTmAKAfitCCktQHNN+upUuL6EkBfFbMDQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.5.0",
         "pretty-format": "30.5.1"
@@ -12212,6 +12564,8 @@
       "integrity": "sha512-aroZVqwOz/wC2y6pC+obgFWKV9viaQWQTTSB6W5H55+egtUczIfXR/rxExTv92xD/ADYwpqaYfVWx1aqwKg7FA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.5.0",
         "chalk": "^4.1.2",
@@ -12228,6 +12582,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12244,6 +12600,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12261,6 +12619,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12273,7 +12633,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-message-util": {
       "version": "30.5.1",
@@ -12281,6 +12643,8 @@
       "integrity": "sha512-UdQlLdd9wL/Ys7xRErckqwD6wPlSZYueosSWuHc1r2ztGLwlgPvtSJq2+BPEgaEY13WLvfFbmhTj8pba0Sd1jg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@jest/types": "30.5.1",
@@ -12303,6 +12667,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12319,6 +12685,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12336,6 +12704,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12348,7 +12718,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-message-util/node_modules/slash": {
       "version": "3.0.0",
@@ -12356,6 +12728,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12366,6 +12740,8 @@
       "integrity": "sha512-9fVjc3leUpGID2/by/LU4Dvdcp7PFh9LlxS3QRWK3ABm+KtvEVsG/AEGeLY3gKOZsjkBxyfwGltoAVlW7dygHg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/expect-utils": "30.5.1",
         "@jest/types": "30.5.1",
@@ -12391,6 +12767,8 @@
       "integrity": "sha512-wprhLejRtwN6h8ZgaqC0eYjGJ1uMdGPT/+b3eFncbG4NWuuP9QL+vWwRinu9waw7hkOLcpMJGVJAMgBwsPssMQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
@@ -12410,6 +12788,8 @@
       "integrity": "sha512-JKpXGONDcTaunrNVn8KCl6qAnwl06jIkvv70lhq0Ze47lsPx9sH5HoeEUiXX6iFGnliHN/qpIbQ0l38wrVmXaw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "jest-regex-util": "30.5.0",
         "jest-snapshot": "30.5.1"
@@ -12424,6 +12804,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12440,6 +12822,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12457,6 +12841,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12469,7 +12855,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-resolve/node_modules/slash": {
       "version": "3.0.0",
@@ -12477,6 +12865,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12487,6 +12877,8 @@
       "integrity": "sha512-FPlQE4+mwnFxXmpPrSi836KV2ZzvK1g6/nPCT8o5BcoDUUNJQeHo1/Qdkoe/QeoL4M7OeJpbnGUhYKhC1VMdaQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/console": "30.5.1",
         "@jest/environment": "30.5.1",
@@ -12521,6 +12913,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12537,6 +12931,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12554,6 +12950,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12566,7 +12964,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-runtime": {
       "version": "30.5.1",
@@ -12574,6 +12974,8 @@
       "integrity": "sha512-UB88+NRkK2Tw/OqV7dofYcyiUGrVZtD41k/N0xQOs9fG//57XHK7JLWG52HD1UYpUAhjK4xm6DBvFX3yWudsMA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/environment": "30.5.1",
         "@jest/fake-timers": "30.5.1",
@@ -12609,6 +13011,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12625,6 +13029,8 @@
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -12635,6 +13041,8 @@
       "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -12648,6 +13056,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12665,6 +13075,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12677,7 +13089,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-runtime/node_modules/glob": {
       "version": "13.0.6",
@@ -12685,6 +13099,8 @@
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "minimatch": "^10.2.2",
         "minipass": "^7.1.3",
@@ -12703,6 +13119,8 @@
       "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.8"
       },
@@ -12719,6 +13137,8 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12729,6 +13149,8 @@
       "integrity": "sha512-cNWFdSb5xuDGl8hKkAZJ3YtI/PzHpAPFV+HUXWIOG8rMhpDTLVbvAc2d2wRicoYw2wGsJGLaurJT6BLC97bLXQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
@@ -12762,6 +13184,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12778,6 +13202,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12795,6 +13221,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12807,7 +13235,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.8.5",
@@ -12815,6 +13245,8 @@
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12894,6 +13326,8 @@
       "integrity": "sha512-i/buJ56wTpxihE93hQYNMfdOThS87+HGvLZzZJmU4xggPcdTYQq051iwALLCHp3q+SkCGH+EFejQZz5EbBSkkg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.5.0",
         "@jest/types": "30.5.1",
@@ -12912,6 +13346,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12928,6 +13364,8 @@
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12941,6 +13379,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -12958,6 +13398,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -12970,7 +13412,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-watcher": {
       "version": "30.5.1",
@@ -12978,6 +13422,8 @@
       "integrity": "sha512-+FHJ7C+S7b3ySfhA1aFmoa6TztsnwZVv84ycPRn0tVN93np2EU4b8C/KadqA3l6igdjgLBTnUotab9ER0HLG8A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/test-result": "30.5.1",
         "@jest/types": "30.5.1",
@@ -12998,6 +13444,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -13014,6 +13462,8 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -13031,6 +13481,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -13043,7 +13495,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest-worker": {
       "version": "30.5.1",
@@ -13224,19 +13678,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -13317,6 +13758,8 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -14516,6 +14959,8 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -14653,6 +15098,8 @@
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -14689,6 +15136,8 @@
       "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "napi-postinstall": "lib/cli.js"
       },
@@ -14725,7 +15174,9 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-exports-info": {
       "version": "1.6.2",
@@ -14772,7 +15223,9 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.54",
@@ -14969,6 +15422,8 @@
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -15122,6 +15577,8 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -15220,6 +15677,8 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -15229,7 +15688,9 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/package-manager-detector": {
       "version": "1.8.0",
@@ -15317,6 +15778,8 @@
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
@@ -15334,6 +15797,8 @@
       "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -15395,6 +15860,8 @@
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -15405,6 +15872,8 @@
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -15418,6 +15887,8 @@
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -15432,6 +15903,8 @@
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -15445,6 +15918,8 @@
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -15461,6 +15936,8 @@
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -15650,6 +16127,8 @@
       "integrity": "sha512-byhRAPguVKMQIj4kjJwJ5lAskVhfuiSdiYl/aLTWpgkGEmic2jYhJh1yE9ih8Ox44Xg9ccCT11/S6QrzSJuNrg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/react-is-18": "npm:react-is@^18.3.1",
         "@jest/react-is-19": "npm:react-is@^19.2.5",
@@ -15666,6 +16145,8 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15710,7 +16191,9 @@
           "url": "https://opencollective.com/fast-check"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/qified": {
       "version": "0.10.1",
@@ -15929,6 +16412,8 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15983,6 +16468,8 @@
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "resolve-from": "^5.0.0"
       },
@@ -16293,7 +16780,9 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -16463,7 +16952,9 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -16471,6 +16962,8 @@
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -16484,6 +16977,8 @@
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16518,6 +17013,8 @@
       "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
@@ -16532,6 +17029,8 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16542,6 +17041,8 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -16573,6 +17074,8 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -16588,6 +17091,8 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16598,6 +17103,8 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16608,6 +17115,8 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -16756,6 +17265,8 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -16769,6 +17280,8 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16779,6 +17292,8 @@
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16789,6 +17304,8 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -16812,6 +17329,8 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -17244,6 +17763,8 @@
       "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^10.4.1",
@@ -17259,6 +17780,8 @@
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -17269,6 +17792,8 @@
       "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -17283,6 +17808,8 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -17303,7 +17830,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
       "version": "2.1.4",
@@ -17311,6 +17840,8 @@
       "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -17321,6 +17852,8 @@
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.2"
       },
@@ -17336,7 +17869,9 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/test-exclude/node_modules/minimatch": {
       "version": "10.2.6",
@@ -17344,6 +17879,8 @@
       "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.8"
       },
@@ -17360,6 +17897,8 @@
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -17509,6 +18048,8 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -17519,6 +18060,8 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17774,16 +18317,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
@@ -17791,6 +18324,8 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.4"
       },
@@ -17876,6 +18411,8 @@
       "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -18158,6 +18695,8 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -18176,6 +18715,8 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18186,6 +18727,8 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -18202,6 +18745,8 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -18214,7 +18759,9 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -18222,6 +18769,8 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18232,6 +18781,8 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -18247,6 +18798,8 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -18305,6 +18858,8 @@
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -18319,6 +18874,8 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -18378,6 +18935,8 @@
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -18397,6 +18956,8 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -18407,6 +18968,8 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18417,6 +18980,8 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18427,6 +18992,8 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -18442,6 +19009,8 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "start": "npm run build -- -w",
     "clean": "del-cli dist types",
     "prebuild": "npm run clean",
-    "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.ts\" --write",
+    "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.{ts,cts,mts}\" --write",
     "build": "npm-run-all -p \"build:**\"",
     "commitlint": "commitlint --from=main",
     "security": "npm audit --omit=dev",
@@ -51,9 +51,9 @@
     "fix:code": "npm run lint:code -- --fix",
     "fix:prettier": "npm run lint:prettier -- --write",
     "fix": "npm-run-all -l fix:code fix:prettier",
-    "test:only": "cross-env NODE_OPTIONS=--experimental-vm-modules NODE_ENV=test jest --testTimeout=60000",
+    "test:only": "cross-env NODE_ENV=test node --test --test-timeout=60000 --test-reporter=spec --test-reporter-destination=stdout \"test/**/*.test.js\"",
     "test:watch": "npm run test:only -- --watch",
-    "test:coverage": "npm run test:only -- --collectCoverageFrom=\"src/**/*.{js,cjs}\" --coverage",
+    "test:coverage": "cross-env NODE_ENV=test node --test --test-timeout=60000 --experimental-test-coverage --test-coverage-include=\"src/**\" --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info \"test/**/*.test.js\"",
     "pretest": "npm run lint",
     "test": "npm run test:coverage",
     "prepare": "npm run build",
@@ -78,8 +78,6 @@
     "@changesets/get-github-info": "^0.8.0",
     "@commitlint/cli": "^21.2.2",
     "@commitlint/config-conventional": "^21.2.2",
-    "@jest/globals": "^30.5.1",
-    "@types/fs-extra": "^11.0.4",
     "@types/micromatch": "^4.0.10",
     "@types/node": "^26.4.1",
     "@types/normalize-path": "^3.0.2",
@@ -92,10 +90,8 @@
     "eslint": "^10.10.0",
     "eslint-config-webpack": "^4.9.6",
     "file-loader": "^6.2.0",
-    "fs-extra": "^11.4.0",
     "globals": "^17.12.0",
     "husky": "^9.1.7",
-    "jest": "^30.5.1",
     "lint-staged": "^17.5.0",
     "npm-run-all": "^4.1.5",
     "postcss-scss": "^4.0.9",
@@ -118,6 +114,6 @@
     }
   },
   "engines": {
-    "node": ">= 20.9.0"
+    "node": ">= 22.12.0"
   }
 }

--- a/test/autofix-stop.test.js
+++ b/test/autofix-stop.test.js
@@ -1,7 +1,9 @@
+import assert from "node:assert/strict";
+import { cpSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { copySync, removeSync } from "fs-extra";
+import { after, before, describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("autofix stop", () => {
   const entry = join(import.meta.dirname, "fixtures/nonfixable-clone.js");
@@ -9,8 +11,8 @@ describe("autofix stop", () => {
   let changed = false;
   let watcher;
 
-  beforeAll(async () => {
-    copySync(join(import.meta.dirname, "fixtures/nonfixable.js"), entry);
+  before(async () => {
+    cpSync(join(import.meta.dirname, "fixtures/nonfixable.js"), entry);
     const chokidar = (await import("chokidar")).default;
 
     watcher = chokidar.watch(entry);
@@ -19,15 +21,15 @@ describe("autofix stop", () => {
     });
   });
 
-  afterAll(() => {
+  after(() => {
     watcher.close();
-    removeSync(entry);
+    rmSync(entry, { force: true, recursive: true });
   });
 
   it("should not change file if there are no fixable errors/warnings", async () => {
     const compiler = pack("nonfixable-clone", { fix: true });
 
     await compiler.runAsync();
-    expect(changed).toBe(false);
+    assert.strictEqual(changed, false);
   });
 });

--- a/test/autofix.test.js
+++ b/test/autofix.test.js
@@ -1,43 +1,36 @@
+import assert from "node:assert/strict";
+import { cpSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
 
-import { copySync, readFileSync, removeSync } from "fs-extra";
-
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("autofix stop", () => {
   const entry = join(import.meta.dirname, "fixtures/fixable-clone.js");
 
-  beforeAll(() => {
-    copySync(join(import.meta.dirname, "fixtures/fixable.js"), entry);
+  before(() => {
+    cpSync(join(import.meta.dirname, "fixtures/fixable.js"), entry);
   });
 
-  afterAll(() => {
-    removeSync(entry);
+  after(() => {
+    rmSync(entry, { force: true, recursive: true });
   });
 
-  it.each([[{}]])(
-    "should not throw error if file ok after auto-fixing",
-    async (cfg) => {
-      const compiler = pack("fixable-clone", {
-        ...cfg,
-        fix: true,
-        extensions: ["js", "cjs", "mjs"],
-        overrideConfig: {
-          rules: { semi: ["error", "always"] },
-        },
-      });
+  it("should not throw error if file ok after auto-fixing", async () => {
+    const compiler = pack("fixable-clone", {
+      fix: true,
+      extensions: ["js", "cjs", "mjs"],
+      overrideConfig: {
+        rules: { semi: ["error", "always"] },
+      },
+    });
 
-      const stats = await compiler.runAsync();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
-      expect(readFileSync(entry).toString("utf8")).toMatchInlineSnapshot(`
-        "function foo() {
-          return true;
-        }
-
-        foo();
-        "
-      `);
-    },
-  );
+    const stats = await compiler.runAsync();
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
+    assert.strictEqual(
+      readFileSync(entry).toString("utf8"),
+      "function foo() {\n  return true;\n}\n\nfoo();\n",
+    );
+  });
 });

--- a/test/autofix.test.js
+++ b/test/autofix.test.js
@@ -28,8 +28,9 @@ describe("autofix stop", () => {
     const stats = await compiler.runAsync();
     assert.strictEqual(stats.hasWarnings(), false);
     assert.strictEqual(stats.hasErrors(), false);
+    // Git checks the fixture out with CRLF on Windows and ESLint keeps it.
     assert.strictEqual(
-      readFileSync(entry).toString("utf8"),
+      readFileSync(entry, "utf8").replaceAll("\r\n", "\n"),
       "function foo() {\n  return true;\n}\n\nfoo();\n",
     );
   });

--- a/test/cached.test.js
+++ b/test/cached.test.js
@@ -1,23 +1,24 @@
+import assert from "node:assert/strict";
+import { rmSync } from "node:fs";
 import { join } from "node:path";
-
-import { removeSync } from "fs-extra";
+import { after, beforeEach, describe, it } from "node:test";
 
 import webpack from "webpack";
 
-import conf from "./utils/conf";
+import conf from "./utils/conf.js";
 
 describe("error (cached module)", () => {
   const cacheLocation = join(import.meta.dirname, "cache");
 
   beforeEach(() => {
-    removeSync(cacheLocation);
+    rmSync(cacheLocation, { force: true, recursive: true });
   });
 
-  afterAll(() => {
-    removeSync(cacheLocation);
+  after(() => {
+    rmSync(cacheLocation, { force: true, recursive: true });
   });
 
-  it("should return error even if module is cached", (done) => {
+  it("should return error even if module is cached", (t, done) => {
     const config = conf("error");
     config.cache = {
       type: "filesystem",
@@ -30,16 +31,16 @@ describe("error (cached module)", () => {
     const c1 = webpack(config);
 
     c1.run((err1, stats1) => {
-      expect(err1).toBeNull();
-      expect(stats1.hasWarnings()).toBe(false);
-      expect(stats1.hasErrors()).toBe(true);
+      assert.strictEqual(err1, null);
+      assert.strictEqual(stats1.hasWarnings(), false);
+      assert.strictEqual(stats1.hasErrors(), true);
 
       c1.close(() => {
         const c2 = webpack(config);
         c2.run((err2, stats2) => {
-          expect(err2).toBeNull();
-          expect(stats2.hasWarnings()).toBe(false);
-          expect(stats2.hasErrors()).toBe(true);
+          assert.strictEqual(err2, null);
+          assert.strictEqual(stats2.hasWarnings(), false);
+          assert.strictEqual(stats2.hasErrors(), true);
 
           done();
         });

--- a/test/child-compiler.test.js
+++ b/test/child-compiler.test.js
@@ -1,6 +1,9 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
 import webpack from "webpack";
 
-import conf from "./utils/conf";
+import conf from "./utils/conf.js";
 
 const PLUGIN_NAME = "ChildPlugin";
 class ChildPlugin {
@@ -24,7 +27,7 @@ class ChildPlugin {
 }
 
 describe("child compiler", () => {
-  it("should have linting process", (done) => {
+  it("should have linting process", (t, done) => {
     const config = conf("good");
     config.plugins.push(
       new ChildPlugin({
@@ -34,9 +37,9 @@ describe("child compiler", () => {
       }),
     );
     webpack(config).run((err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasErrors()).toBe(false);
-      expect(stats.hasWarnings()).toBe(true);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasErrors(), false);
+      assert.strictEqual(stats.hasWarnings(), true);
       done();
     });
   });

--- a/test/circular-plugin.test.js
+++ b/test/circular-plugin.test.js
@@ -1,4 +1,7 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("circular plugin", () => {
   it("should support plugins with circular configs", async () => {
@@ -27,7 +30,7 @@ describe("circular plugin", () => {
     const compiler = pack("good", loaderOptions);
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,6 +1,8 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("context", () => {
   it("absolute", async () => {
@@ -9,15 +11,15 @@ describe("context", () => {
     });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("relative", async () => {
     const compiler = pack("good", { context: "../fixtures/" });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/emit-error.test.js
+++ b/test/emit-error.test.js
@@ -1,25 +1,28 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("emit error", () => {
   it("should not emit errors if emitError is false", async () => {
     const compiler = pack("error", { emitError: false });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should emit errors if emitError is undefined", async () => {
     const compiler = pack("error", {});
 
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should emit errors if emitError is true", async () => {
     const compiler = pack("error", { emitError: true });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should emit errors, but not warnings if emitError is true and emitWarning is false", async () => {
@@ -29,15 +32,15 @@ describe("emit error", () => {
     });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should emit errors and warnings if emitError is true and emitWarning is undefined", async () => {
     const compiler = pack("full-of-problems", { emitError: true });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), true);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 });

--- a/test/emit-warning.test.js
+++ b/test/emit-warning.test.js
@@ -1,25 +1,28 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("emit warning", () => {
   it("should not emit warnings if emitWarning is false", async () => {
     const compiler = pack("warn", { emitWarning: false });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
   });
 
   it("should emit warnings if emitWarning is undefined", async () => {
     const compiler = pack("warn", {});
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), true);
   });
 
   it("should emit warnings if emitWarning is true", async () => {
     const compiler = pack("warn", { emitWarning: true });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), true);
   });
 
   it("should emit warnings, but not warnings if emitWarning is true and emitError is false", async () => {
@@ -29,15 +32,15 @@ describe("emit warning", () => {
     });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), true);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should emit warnings and errors if emitWarning is true and emitError is undefined", async () => {
     const compiler = pack("full-of-problems", { emitWarning: true });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), true);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 });

--- a/test/empty.test.js
+++ b/test/empty.test.js
@@ -1,11 +1,13 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
 import webpack from "webpack";
 
-import LintPlugin from "../src";
+import LintPlugin from "../src/index.js";
 
 describe("empty", () => {
-  it("no error when no files matching", (done) => {
+  it("no error when no files matching", (t, done) => {
     const compiler = webpack({
       context: join(import.meta.dirname, "fixtures", "empty"),
       mode: "development",
@@ -14,8 +16,8 @@ describe("empty", () => {
     });
 
     compiler.run((err, stats) => {
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), false);
       done();
     });
   });

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,14 +1,16 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("error", () => {
   it("should return error if file is bad", async () => {
     const compiler = pack("error");
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should propagate eslint exceptions as errors", async () => {
@@ -16,8 +18,8 @@ describe("error", () => {
     const compiler = pack("good", { eslintPath });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toContain("Oh no!");
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message.includes("Oh no!"));
   });
 });

--- a/test/eslint-lint.test.js
+++ b/test/eslint-lint.test.js
@@ -1,7 +1,9 @@
+import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import { join } from "node:path";
+import { beforeEach, describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 const require = createRequire(import.meta.url);
 const eslintPath = join(import.meta.dirname, "mock/eslint-recorder");
@@ -15,27 +17,31 @@ describe("eslint lint", () => {
     const compiler = pack("lint-one", { eslintPath });
 
     await compiler.runAsync();
-    expect(require(eslintPath)._calls).toHaveLength(1);
+    assert.strictEqual(require(eslintPath)._calls.length, 1);
   });
 
   it("should lint two files", async () => {
     const compiler = pack("lint-two", { eslintPath });
 
     await compiler.runAsync();
-    expect(require(eslintPath)._calls[0]).toEqual([
-      expect.stringMatching("lint-two-entry.js"),
-      expect.stringMatching("lint.js"),
-    ]);
+
+    const [files] = require(eslintPath)._calls;
+
+    assert.strictEqual(files.length, 2);
+    assert.match(files[0], /lint-two-entry\.js/u);
+    assert.match(files[1], /lint\.js/u);
   });
 
   it("should lint more files", async () => {
     const compiler = pack("lint-more", { eslintPath });
 
     await compiler.runAsync();
-    expect(require(eslintPath)._calls[0]).toEqual([
-      expect.stringMatching("lint-more-entry.js"),
-      expect.stringMatching("lint-more.js"),
-      expect.stringMatching("lint.js"),
-    ]);
+
+    const [files] = require(eslintPath)._calls;
+
+    assert.strictEqual(files.length, 3);
+    assert.match(files[0], /lint-more-entry\.js/u);
+    assert.match(files[1], /lint-more\.js/u);
+    assert.match(files[2], /lint\.js/u);
   });
 });

--- a/test/eslint-options.test.js
+++ b/test/eslint-options.test.js
@@ -1,4 +1,7 @@
-import { getESLintOptions } from "../src/linters/eslint";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getESLintOptions } from "../src/linters/eslint.js";
 
 describe("eslint options", () => {
   it("should filter loader options", () => {
@@ -6,7 +9,7 @@ describe("eslint options", () => {
       formatter: "table",
       ignore: false,
     };
-    expect(getESLintOptions(options)).toStrictEqual({
+    assert.deepStrictEqual(getESLintOptions(options), {
       ignore: false,
     });
   });
@@ -24,7 +27,7 @@ describe("eslint options", () => {
       quiet: false,
       outputReport: true,
     };
-    expect(getESLintOptions(options)).toStrictEqual({
+    assert.deepStrictEqual(getESLintOptions(options), {
       fix: true,
     });
   });

--- a/test/eslint-path.test.js
+++ b/test/eslint-path.test.js
@@ -1,6 +1,8 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("eslint path", () => {
   it("should use another instance of eslint via eslintPath config", async () => {
@@ -8,8 +10,8 @@ describe("eslint path", () => {
     const compiler = pack("good", { eslintPath });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toContain("Fake error");
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message.includes("Fake error"));
   });
 });

--- a/test/eslintrc-config.test.js
+++ b/test/eslintrc-config.test.js
@@ -1,12 +1,14 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
 import { ESLint } from "eslint";
-import pack from "./utils/pack";
+
+import pack from "./utils/pack.js";
 
 (ESLint && Number.parseFloat(ESLint.version) >= 10 ? describe.skip : describe)(
   "succeed on eslintrc-configuration",
   () => {
-    // eslint-disable-next-line jest/require-top-level-describe, jest/consistent-test-it
     it("should work with eslintrc configuration type", async () => {
       const overrideConfigFile = join(
         import.meta.dirname,
@@ -21,10 +23,10 @@ import pack from "./utils/pack";
       const stats = await compiler.runAsync();
       const { errors } = stats.compilation;
 
-      expect(stats.hasErrors()).toBe(true);
-      expect(errors).toHaveLength(1);
-      expect(errors[0].message).toContain("full-of-problems.js");
-      expect(stats.hasWarnings()).toBe(true);
+      assert.strictEqual(stats.hasErrors(), true);
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0].message.includes("full-of-problems.js"));
+      assert.strictEqual(stats.hasWarnings(), true);
     });
   },
 );

--- a/test/exclude.test.js
+++ b/test/exclude.test.js
@@ -1,27 +1,30 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("exclude", () => {
   it("should exclude with globs", async () => {
     const compiler = pack("exclude", { exclude: ["*error*"] });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should exclude files", async () => {
     const compiler = pack("exclude", { exclude: ["error.js"] });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should exclude folders", async () => {
     const compiler = pack("exclude-folder", { exclude: ["folder"] });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/fail-on-config.test.js
+++ b/test/fail-on-config.test.js
@@ -1,12 +1,14 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
 import { ESLint } from "eslint";
-import pack from "./utils/pack";
+
+import pack from "./utils/pack.js";
 
 (ESLint && Number.parseFloat(ESLint.version) >= 10 ? describe.skip : describe)(
   "fail on config",
   () => {
-    // eslint-disable-next-line jest/require-top-level-describe, jest/consistent-test-it
     it("fails when .eslintrc is not a proper format", async () => {
       const overrideConfigFile = join(import.meta.dirname, ".badeslintrc");
       const compiler = pack("error", {
@@ -16,10 +18,11 @@ import pack from "./utils/pack";
 
       const stats = await compiler.runAsync();
       const { errors } = stats.compilation;
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(errors).toHaveLength(1);
-      expect(errors[0].message).toMatch(
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
+      assert.strictEqual(errors.length, 1);
+      assert.match(
+        errors[0].message,
         /ESLint configuration in --config is invalid/i,
       );
     });

--- a/test/fail-on-error.test.js
+++ b/test/fail-on-error.test.js
@@ -1,23 +1,26 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("fail on error", () => {
   it("should emits errors", async () => {
     const compiler = pack("error", { failOnError: true });
 
-    await expect(compiler.runAsync()).rejects.toThrow("error");
+    await assert.rejects(compiler.runAsync(), /error/u);
   });
 
   it("should emit warnings when disabled", async () => {
     const compiler = pack("error", { failOnError: false });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should correctly identifies a success", async () => {
     const compiler = pack("good", { failOnError: true });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/fail-on-warning.test.js
+++ b/test/fail-on-warning.test.js
@@ -1,16 +1,19 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("fail on warning", () => {
   it("should emits errors", async () => {
     const compiler = pack("warn", { failOnWarning: true });
 
-    await expect(compiler.runAsync()).rejects.toThrow("warning");
+    await assert.rejects(compiler.runAsync(), /warning/u);
   });
 
   it("should correctly identifies a success", async () => {
     const compiler = pack("good", { failOnWarning: true });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/flat-config.test.js
+++ b/test/flat-config.test.js
@@ -1,5 +1,8 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
-import pack from "./utils/pack";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("succeed on flat-configuration", () => {
   it("should work with flat configuration type", async () => {
@@ -16,9 +19,9 @@ describe("succeed on flat-configuration", () => {
     const stats = await compiler.runAsync();
     const { errors } = stats.compilation;
 
-    expect(stats.hasErrors()).toBe(true);
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toMatch(/full-of-problems\.js/i);
-    expect(stats.hasWarnings()).toBe(true);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.strictEqual(errors.length, 1);
+    assert.match(errors[0].message, /full-of-problems\.js/i);
+    assert.strictEqual(stats.hasWarnings(), true);
   });
 });

--- a/test/formatter-custom.test.js
+++ b/test/formatter-custom.test.js
@@ -1,5 +1,8 @@
+import assert from "node:assert/strict";
 import { createRequire } from "node:module";
-import pack from "./utils/pack";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 const require = createRequire(import.meta.url);
 
@@ -10,28 +13,28 @@ describe("formatter eslint", () => {
     const compiler = pack("error", { formatter });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toBeTruthy();
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message);
     const message = JSON.parse(
       stats.compilation.errors[0].message.replace("[eslint] ", ""),
     );
-    expect(message.formatter).toBe("mock");
-    expect(message.results).toBeTruthy();
+    assert.strictEqual(message.formatter, "mock");
+    assert.ok(message.results);
   });
 
   it("should use custom formatter as string", async () => {
-    const formatter = "./test/mock/formatter";
+    const formatter = "./test/mock/formatter/index.js";
     const compiler = pack("error", { formatter });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toBeTruthy();
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message);
     const message = JSON.parse(
       stats.compilation.errors[0].message.replace("[eslint] ", ""),
     );
-    expect(message.formatter).toBe("mock");
-    expect(message.results).toBeTruthy();
+    assert.strictEqual(message.formatter, "mock");
+    assert.ok(message.results);
   });
 });

--- a/test/formatter-eslint.test.js
+++ b/test/formatter-eslint.test.js
@@ -1,12 +1,15 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("formatter eslint", () => {
   it("should use eslint formatter", async () => {
     const compiler = pack("error");
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toBeTruthy();
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message);
   });
 });

--- a/test/formatter-official.test.js
+++ b/test/formatter-official.test.js
@@ -1,12 +1,15 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("formatter official", () => {
   it("should use official formatter", async () => {
     const compiler = pack("error", { formatter: "json" });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toBeTruthy();
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message);
   });
 });

--- a/test/formatter-write.test.js
+++ b/test/formatter-write.test.js
@@ -1,12 +1,14 @@
+import assert from "node:assert/strict";
+import { readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
-import { readFileSync, removeSync } from "fs-extra";
 import webpack from "webpack";
 
-import conf from "./utils/conf";
+import conf from "./utils/conf.js";
 
 describe("formatter write", () => {
-  it("should write results to relative file with a custom formatter", (done) => {
+  it("should write results to relative file with a custom formatter", (t, done) => {
     const outputFilename = "outputReport-relative.txt";
     const config = conf("error", {
       formatter: "json",
@@ -17,21 +19,24 @@ describe("formatter write", () => {
     });
 
     const outputFilepath = join(config.output.path, outputFilename);
-    removeSync(outputFilepath);
+    rmSync(outputFilepath, { force: true, recursive: true });
 
     const compiler = webpack(config);
     compiler.run((err, stats) => {
       const contents = readFileSync(outputFilepath, "utf8");
 
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(stats.compilation.errors[0].message).toBe(`[eslint] ${contents}`);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
+      assert.strictEqual(
+        stats.compilation.errors[0].message,
+        `[eslint] ${contents}`,
+      );
       done();
     });
   });
 
-  it("should write results to absolute file with a same formatter", (done) => {
+  it("should write results to absolute file with a same formatter", (t, done) => {
     const outputFilename = "outputReport-absolute.txt";
     const outputFilepath = join(import.meta.dirname, "outputs", outputFilename);
     const config = conf("error", {
@@ -40,16 +45,19 @@ describe("formatter write", () => {
       },
     });
 
-    removeSync(outputFilepath);
+    rmSync(outputFilepath, { force: true, recursive: true });
 
     const compiler = webpack(config);
     compiler.run((err, stats) => {
       const contents = readFileSync(outputFilepath, "utf8");
 
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
-      expect(stats.compilation.errors[0].message).toBe(`[eslint] ${contents}`);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
+      assert.strictEqual(
+        stats.compilation.errors[0].message,
+        `[eslint] ${contents}`,
+      );
       done();
     });
   });

--- a/test/ignore.test.js
+++ b/test/ignore.test.js
@@ -1,5 +1,9 @@
-import LintError from "../src/LintError";
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import LintError from "../src/LintError.js";
+
+import pack from "./utils/pack.js";
 
 describe("eslintignore", () => {
   it("should ignores files present in .eslintignore", async () => {
@@ -9,9 +13,10 @@ describe("eslintignore", () => {
     });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.deepStrictEqual(
       stats.compilation.errors.filter((x) => x instanceof LintError),
-    ).toEqual([]);
+      [],
+    );
   });
 });

--- a/test/lint-dirty-modules-only.test.js
+++ b/test/lint-dirty-modules-only.test.js
@@ -1,9 +1,9 @@
-import { writeFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
 
-import { removeSync } from "fs-extra";
-
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 const target = join(
   import.meta.dirname,
@@ -18,10 +18,10 @@ describe("lint dirty modules only", () => {
     if (watch) {
       watch.close();
     }
-    removeSync(target);
+    rmSync(target, { force: true, recursive: true });
   });
 
-  it("skips linting on initial run", (done) => {
+  it("skips linting on initial run", (t, done) => {
     writeFileSync(target, "const foo = false\n");
 
     // eslint-disable-next-line no-use-before-define
@@ -32,21 +32,19 @@ describe("lint dirty modules only", () => {
     watch = compiler.watch({}, (err, stats) => next(err, stats));
 
     function secondPass(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
       const { errors } = stats.compilation;
-      expect(errors).toHaveLength(1);
-      expect(stats.compilation.errors[0].message).toEqual(
-        expect.stringMatching("no-unused-vars"),
-      );
+      assert.strictEqual(errors.length, 1);
+      assert.match(stats.compilation.errors[0].message, /no-unused-vars/u);
       done();
     }
 
     function firstPass(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), false);
 
       next = secondPass;
 

--- a/test/multiple-instances.test.js
+++ b/test/multiple-instances.test.js
@@ -1,6 +1,10 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
-import LintPlugin from "../src";
-import pack from "./utils/pack";
+import { describe, it } from "node:test";
+
+import LintPlugin from "../src/index.js";
+
+import pack from "./utils/pack.js";
 
 describe("multiple instances", () => {
   it("should don't fail", async () => {
@@ -42,8 +46,8 @@ describe("multiple instances", () => {
     );
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should fail on first instance", async () => {
@@ -84,7 +88,7 @@ describe("multiple instances", () => {
       },
     );
 
-    await expect(compiler.runAsync()).rejects.toThrow("error.js");
+    await assert.rejects(compiler.runAsync(), /error\.js/u);
   });
 
   it("should fail on second instance", async () => {
@@ -125,6 +129,6 @@ describe("multiple instances", () => {
       },
     );
 
-    await expect(compiler.runAsync()).rejects.toThrow("error.js");
+    await assert.rejects(compiler.runAsync(), /error\.js/u);
   });
 });

--- a/test/ok.test.js
+++ b/test/ok.test.js
@@ -1,11 +1,14 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("ok", () => {
   it("should don't throw error if file is ok", async () => {
     const compiler = pack("good");
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -1,4 +1,7 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("parameters", () => {
   it("should supports query strings parameters", async () => {
@@ -10,7 +13,7 @@ describe("parameters", () => {
     const compiler = pack("good", loaderOptions);
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,4 +1,7 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("query", () => {
   it("should correctly resolve file despite query path", async () => {
@@ -15,7 +18,7 @@ describe("query", () => {
     );
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/quiet.test.js
+++ b/test/quiet.test.js
@@ -1,19 +1,22 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("quiet", () => {
   it("should not emit warnings if quiet is set", async () => {
     const compiler = pack("warn", { quiet: true });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should emit errors, but not emit warnings if quiet is set", async () => {
     const compiler = pack("full-of-problems", { quiet: true });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 });

--- a/test/resource-query.test.js
+++ b/test/resource-query.test.js
@@ -1,4 +1,7 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("resource-query", () => {
   it("should exclude the match resource query", async () => {
@@ -14,7 +17,7 @@ describe("resource-query", () => {
     );
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/stylelint/context.test.js
+++ b/test/stylelint/context.test.js
@@ -1,6 +1,8 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("context", () => {
   it("absolute", async () => {
@@ -8,14 +10,14 @@ describe("context", () => {
       context: join(import.meta.dirname, "fixtures/good"),
     });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("relative", async () => {
     const compiler = pack("good", { context: "../good/" });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/stylelint/emit-error.test.js
+++ b/test/stylelint/emit-error.test.js
@@ -1,22 +1,25 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("emit error", () => {
   it("should not emit errors if emitError is false", async () => {
     const compiler = pack("error", { emitError: false });
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should emit errors if emitError is undefined", async () => {
     const compiler = pack("error");
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should emit errors if emitError is true", async () => {
     const compiler = pack("error", { emitError: true });
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should emit errors, but not warnings if emitError is true and emitWarning is false", async () => {
@@ -26,14 +29,14 @@ describe("emit error", () => {
     });
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should emit errors and warnings if emitError is true and emitWarning is undefined", async () => {
     const compiler = pack("full-of-problems", { emitError: true });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), true);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 });

--- a/test/stylelint/emit-warning.test.js
+++ b/test/stylelint/emit-warning.test.js
@@ -1,22 +1,25 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("emit warning", () => {
   it("should not emit warnings if emitWarning is false", async () => {
     const compiler = pack("warning", { emitWarning: false });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
   });
 
   it("should emit warnings if emitWarning is undefined", async () => {
     const compiler = pack("warning");
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), true);
   });
 
   it("should emit warnings if emitWarning is true", async () => {
     const compiler = pack("warning", { emitWarning: true });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), true);
   });
 
   it("should emit warnings, but not warnings if emitWarning is true and emitError is false", async () => {
@@ -25,14 +28,14 @@ describe("emit warning", () => {
       emitError: false,
     });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), true);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should emit warnings and errors if emitWarning is true and emitError is undefined", async () => {
     const compiler = pack("full-of-problems", { emitWarning: true });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), true);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 });

--- a/test/stylelint/empty.test.js
+++ b/test/stylelint/empty.test.js
@@ -1,6 +1,9 @@
-import LintPlugin from "../../src";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import LintPlugin from "../../src/index.js";
+
+import pack from "./utils/pack.js";
 
 describe("empty", () => {
   it("no error when no files matching", async () => {
@@ -12,7 +15,7 @@ describe("empty", () => {
       },
     );
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/stylelint/error.test.js
+++ b/test/stylelint/error.test.js
@@ -1,19 +1,15 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
-import { jest } from "@jest/globals";
-
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("error", () => {
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   it("should return error if file is bad", async () => {
     const compiler = pack("error");
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should propagate stylelint lint exceptions as errors", async () => {
@@ -22,8 +18,8 @@ describe("error", () => {
 
     const compiler = pack("good", { stylelintPath: mockStylelintPath });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should propagate stylelint load exceptions as errors", async () => {
@@ -35,7 +31,7 @@ describe("error", () => {
 
     const compiler = pack("good", { stylelintPath: mockStylelintPath });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 });

--- a/test/stylelint/exclude.test.js
+++ b/test/stylelint/exclude.test.js
@@ -1,24 +1,27 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("exclude", () => {
   it("should exclude with globs", async () => {
     const compiler = pack("exclude", { exclude: ["*test*"] });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should exclude files", async () => {
     const compiler = pack("exclude", { exclude: ["test.scss"] });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should exclude folders", async () => {
     const compiler = pack("exclude-folder", { exclude: ["folder"] });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/stylelint/fail-on-config.test.js
+++ b/test/stylelint/fail-on-config.test.js
@@ -1,6 +1,8 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("fail on config", () => {
   it("fails when .stylelintrc is not a proper format", async () => {
@@ -8,8 +10,8 @@ describe("fail on config", () => {
     const compiler = pack("error", { configFile });
     const stats = await compiler.runAsync();
     const { errors } = stats.compilation;
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(errors).toHaveLength(1);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.strictEqual(errors.length, 1);
   });
 });

--- a/test/stylelint/fail-on-error.test.js
+++ b/test/stylelint/fail-on-error.test.js
@@ -1,21 +1,24 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("fail on error", () => {
   it("should fail the build", async () => {
     const compiler = pack("error", { failOnError: true });
 
-    await expect(compiler.runAsync()).rejects.toThrow("color-named");
+    await assert.rejects(compiler.runAsync(), /color-named/u);
   });
 
   it("should report errors without failing when disabled", async () => {
     const compiler = pack("error", { failOnError: false });
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should correctly identify a success", async () => {
     const compiler = pack("good", { failOnError: true });
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/stylelint/fail-on-warning.test.js
+++ b/test/stylelint/fail-on-warning.test.js
@@ -1,15 +1,18 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("fail on warning", () => {
   it("should fail the build", async () => {
     const compiler = pack("warning", { failOnWarning: true });
 
-    await expect(compiler.runAsync()).rejects.toThrow("color-hex-length");
+    await assert.rejects(compiler.runAsync(), /color-hex-length/u);
   });
 
   it("should correctly identify a success", async () => {
     const compiler = pack("good", { failOnWarning: true });
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/stylelint/formatter.test.js
+++ b/test/stylelint/formatter.test.js
@@ -1,28 +1,31 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("formatter", () => {
   it("should use default formatter", async () => {
     const compiler = pack("error");
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toBeTruthy();
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message);
   });
 
   it("should use default formatter when invalid", async () => {
     const compiler = pack("error", { formatter: "invalid" });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toBeTruthy();
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message);
   });
 
   it("should use string formatter", async () => {
     const compiler = pack("error", { formatter: "json" });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toBeTruthy();
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message);
   });
 
   it("should use function formatter", async () => {
@@ -34,8 +37,8 @@ describe("formatter", () => {
 
     const compiler = pack("error", { formatter: verboseFormatter });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toBeTruthy();
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message);
   });
 });

--- a/test/stylelint/lint-dirty-modules-only.test.js
+++ b/test/stylelint/lint-dirty-modules-only.test.js
@@ -1,8 +1,9 @@
+import assert from "node:assert/strict";
+import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
 
-import { removeSync, writeFileSync } from "fs-extra";
-
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 const target = join(
   import.meta.dirname,
@@ -16,10 +17,10 @@ describe("lint dirty modules only", () => {
     if (watch) {
       watch.close();
     }
-    removeSync(target);
+    rmSync(target, { force: true, recursive: true });
   });
 
-  it("skips linting on initial run", (done) => {
+  it("skips linting on initial run", (t, done) => {
     writeFileSync(target, "body { }\n");
 
     // eslint-disable-next-line no-use-before-define
@@ -30,20 +31,20 @@ describe("lint dirty modules only", () => {
     watch = compiler.watch({}, (err, stats) => next(err, stats));
 
     function secondPass(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
       const { errors } = stats.compilation;
-      expect(errors).toHaveLength(1);
+      assert.strictEqual(errors.length, 1);
       const [{ message }] = errors;
-      expect(message).toEqual(expect.stringMatching("color-named"));
+      assert.match(message, /color-named/u);
       done();
     }
 
     function firstPass(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), false);
 
       next = secondPass;
 

--- a/test/stylelint/multiple-instances.test.js
+++ b/test/stylelint/multiple-instances.test.js
@@ -1,6 +1,9 @@
-import LintPlugin from "../../src";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import LintPlugin from "../../src/index.js";
+
+import pack from "./utils/pack.js";
 
 describe("multiple instances", () => {
   it("should don't fail", async () => {
@@ -22,8 +25,8 @@ describe("multiple instances", () => {
     );
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should fail on first instance", async () => {
@@ -45,8 +48,8 @@ describe("multiple instances", () => {
     );
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 
   it("should fail on second instance", async () => {
@@ -68,7 +71,7 @@ describe("multiple instances", () => {
     );
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 });

--- a/test/stylelint/ok.test.js
+++ b/test/stylelint/ok.test.js
@@ -1,10 +1,13 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("ok", () => {
   it("should don't throw error if file is ok", async () => {
     const compiler = pack("good");
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/stylelint/output-report.test.js
+++ b/test/stylelint/output-report.test.js
@@ -1,8 +1,9 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
-import { existsSync, readFileSync } from "fs-extra";
-
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("output report", () => {
   it("should output report a default formatter", async () => {
@@ -11,9 +12,9 @@ describe("output report", () => {
       outputReport: { filePath },
     });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(existsSync(join(compiler.outputPath, filePath))).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.strictEqual(existsSync(join(compiler.outputPath, filePath)), true);
   });
 
   it("should output report with a custom formatter", async () => {
@@ -25,11 +26,12 @@ describe("output report", () => {
       },
     });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(existsSync(filePath)).toBe(true);
-    expect(JSON.parse(readFileSync(filePath, "utf8"))).toMatchObject([
-      { source: expect.stringContaining("test.scss") },
-    ]);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.strictEqual(existsSync(filePath), true);
+    const report = JSON.parse(readFileSync(filePath, "utf8"));
+
+    assert.strictEqual(report.length, 1);
+    assert.ok(report[0].source.includes("test.scss"));
   });
 });

--- a/test/stylelint/quiet.test.js
+++ b/test/stylelint/quiet.test.js
@@ -1,17 +1,20 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("quiet", () => {
   it("should not emit warnings if quiet is set", async () => {
     const compiler = pack("warning", { quiet: true });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("should emit errors, but not emit warnings if quiet is set", async () => {
     const compiler = pack("full-of-problems", { quiet: true });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 });

--- a/test/stylelint/stylelint-ignore.test.js
+++ b/test/stylelint/stylelint-ignore.test.js
@@ -1,10 +1,13 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("stylelint ignore", () => {
   it("should ignore file", async () => {
     const compiler = pack("stylelint-ignore");
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/stylelint/stylelint-lint.test.js
+++ b/test/stylelint/stylelint-lint.test.js
@@ -1,7 +1,9 @@
+import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import { join } from "node:path";
+import { beforeEach, describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 const require = createRequire(import.meta.url);
 
@@ -24,18 +26,21 @@ describe("stylelint lint", () => {
       stylelintPath: mockStylelintPath,
     });
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasErrors(), false);
 
     const mock = require(mockStylelintPath);
 
-    const files = [expect.stringMatching("test.scss")];
-    expect(mock._calls[0]).toMatchObject({
-      cache: false,
-      cacheLocation: "node_modules/.cache/lint-webpack-plugin/.stylelintcache",
-      configFile: null,
-      files,
-      quietDeprecationWarnings: true,
-    });
+    const [call] = mock._calls;
+
+    assert.strictEqual(call.cache, false);
+    assert.strictEqual(
+      call.cacheLocation,
+      "node_modules/.cache/lint-webpack-plugin/.stylelintcache",
+    );
+    assert.strictEqual(call.configFile, null);
+    assert.strictEqual(call.quietDeprecationWarnings, true);
+    assert.strictEqual(call.files.length, 1);
+    assert.match(call.files[0], /test\.scss$/u);
   });
 
   it("should lint two files", async () => {
@@ -44,20 +49,21 @@ describe("stylelint lint", () => {
       stylelintPath: mockStylelintPath,
     });
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasErrors(), false);
 
     const mock = require(mockStylelintPath);
 
-    const files = [
-      expect.stringMatching(/test[12]\.scss$/),
-      expect.stringMatching(/test[12]\.scss$/),
-    ];
-    expect(mock._calls[0]).toMatchObject({
-      cache: false,
-      cacheLocation: "node_modules/.cache/lint-webpack-plugin/.stylelintcache",
-      configFile: null,
-      files,
-      quietDeprecationWarnings: true,
-    });
+    const [call] = mock._calls;
+
+    assert.strictEqual(call.cache, false);
+    assert.strictEqual(
+      call.cacheLocation,
+      "node_modules/.cache/lint-webpack-plugin/.stylelintcache",
+    );
+    assert.strictEqual(call.configFile, null);
+    assert.strictEqual(call.quietDeprecationWarnings, true);
+    assert.strictEqual(call.files.length, 2);
+    assert.match(call.files[0], /test[12]\.scss$/u);
+    assert.match(call.files[1], /test[12]\.scss$/u);
   });
 });

--- a/test/stylelint/stylelint-options.test.js
+++ b/test/stylelint/stylelint-options.test.js
@@ -1,4 +1,7 @@
-import { getStylelintOptions } from "../../src/linters/stylelint";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getStylelintOptions } from "../../src/linters/stylelint.js";
 
 describe("eslint options", () => {
   it("should filter plugin options", () => {
@@ -6,7 +9,7 @@ describe("eslint options", () => {
       formatter: "json",
       emitError: false,
     };
-    expect(getStylelintOptions(options)).toStrictEqual({
+    assert.deepStrictEqual(getStylelintOptions(options), {
       formatter: "json",
     });
   });
@@ -23,7 +26,7 @@ describe("eslint options", () => {
       quiet: false,
       outputReport: true,
     };
-    expect(getStylelintOptions(options)).toStrictEqual({
+    assert.deepStrictEqual(getStylelintOptions(options), {
       formatter: "json",
       files: ["file.scss"],
     });

--- a/test/stylelint/stylelint-path.test.js
+++ b/test/stylelint/stylelint-path.test.js
@@ -1,14 +1,16 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("stylelint path", () => {
   it("should use another instance of stylelint via stylelintPath config", async () => {
     const stylelintPath = join(import.meta.dirname, "mock/stylelint");
     const compiler = pack("stylelint-path", { stylelintPath });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toContain("Fake error");
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.ok(stats.compilation.errors[0].message.includes("Fake error"));
   });
 });

--- a/test/stylelint/symbols.test.js
+++ b/test/stylelint/symbols.test.js
@@ -1,10 +1,13 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("symbols", () => {
   it("should return error", async () => {
     const compiler = pack("[symbols]");
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 });

--- a/test/stylelint/threads.test.js
+++ b/test/stylelint/threads.test.js
@@ -1,14 +1,14 @@
+import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import { join } from "node:path";
-
-import { jest } from "@jest/globals";
+import { beforeEach, describe, it } from "node:test";
 
 // @ts-expect-error no types
 import normalizePath from "normalize-path";
 
-import { getLoadedStylelint } from "../../src/linters/stylelint";
+import { getLoadedStylelint } from "../../src/linters/stylelint.js";
 
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 const require = createRequire(import.meta.url);
 
@@ -16,19 +16,19 @@ describe("Threading", () => {
   it("should don't throw error if file is ok with threads", async () => {
     const compiler = pack("good", { threads: 2 });
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 
   it("threaded interface should look like non-threaded interface", async () => {
     const single = getLoadedStylelint("single", {});
     const threaded = getLoadedStylelint("threaded", { threads: 2 });
     for (const key of Object.keys(single)) {
-      expect(typeof single[key]).toEqual(typeof threaded[key]);
+      assert.deepStrictEqual(typeof single[key], typeof threaded[key]);
     }
 
-    expect(single.lintFiles).not.toBe(threaded.lintFiles);
-    expect(single.cleanup).not.toBe(threaded.cleanup);
+    assert.notStrictEqual(single.lintFiles, threaded.lintFiles);
+    assert.notStrictEqual(single.cleanup, threaded.cleanup);
 
     single.cleanup();
     threaded.cleanup();
@@ -45,8 +45,8 @@ describe("Threading", () => {
           normalizePath(join(import.meta.dirname, "fixtures/error/test.scss")),
         ),
       ]);
-      expect(good[0].errored).toBe(false);
-      expect(bad[0].errored).toBe(true);
+      assert.strictEqual(good[0].errored, false);
+      assert.strictEqual(bad[0].errored, true);
     } finally {
       threaded.cleanup();
     }
@@ -54,7 +54,11 @@ describe("Threading", () => {
 
   describe("worker coverage", () => {
     beforeEach(() => {
-      jest.resetModules();
+      // The worker holds its stylelint path in module state, so drop the copy
+      // a previous test set up.
+      delete require.cache[
+        require.resolve("../../src/linters/stylelint-worker.cjs")
+      ];
     });
 
     it("worker can start", async () => {
@@ -68,7 +72,6 @@ describe("Threading", () => {
 
       mock._reset();
 
-      // Now require the worker (fresh copy due to resetModules)
       const {
         lintFiles,
         setup,
@@ -78,10 +81,10 @@ describe("Threading", () => {
 
       await lintFiles("foo");
 
-      expect(mock._calls[0]).toMatchObject({
-        files: "foo",
-        quietDeprecationWarnings: true,
-      });
+      const [call] = mock._calls;
+
+      assert.strictEqual(call.files, "foo");
+      assert.strictEqual(call.quietDeprecationWarnings, true);
     });
   });
 });

--- a/test/stylelint/utils/conf.js
+++ b/test/stylelint/utils/conf.js
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import LintPlugin from "../../../src";
+import LintPlugin from "../../../src/index.js";
 
 // Options the plugin only accepts next to the linter groups, not inside one.
 const PLUGIN_OPTIONS = ["context", "lintDirtyModulesOnly"];

--- a/test/stylelint/utils/pack.js
+++ b/test/stylelint/utils/pack.js
@@ -1,6 +1,6 @@
 import webpack from "webpack";
 
-import conf from "./conf";
+import conf from "./conf.js";
 
 export default (context, pluginConf = {}, webpackConf = {}) => {
   const compiler = webpack(conf(context, pluginConf, webpackConf));

--- a/test/stylelint/warning.test.js
+++ b/test/stylelint/warning.test.js
@@ -1,10 +1,13 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("warning", () => {
   it("should emit warnings", async () => {
     const compiler = pack("warning");
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), true);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/stylelint/watch.test.js
+++ b/test/stylelint/watch.test.js
@@ -1,8 +1,9 @@
+import assert from "node:assert/strict";
+import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
 
-import { removeSync, writeFileSync } from "fs-extra";
-
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 const target = join(import.meta.dirname, "fixtures", "watch", "entry.scss");
 const target2 = join(import.meta.dirname, "fixtures", "watch", "leaf.scss");
@@ -14,22 +15,22 @@ describe("watch", () => {
     if (watch) {
       watch.close();
     }
-    removeSync(target);
-    removeSync(target2);
+    rmSync(target, { force: true, recursive: true });
+    rmSync(target2, { force: true, recursive: true });
   });
 
-  it("should watch", (done) => {
+  it("should watch", (t, done) => {
     const compiler = pack("good");
 
     watch = compiler.watch({}, (err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), false);
       done();
     });
   });
 
-  it("should watch with unique messages", (done) => {
+  it("should watch with unique messages", (t, done) => {
     writeFileSync(target, "#foo { background: black; }\n");
     writeFileSync(target2, "");
 
@@ -39,49 +40,49 @@ describe("watch", () => {
     watch = compiler.watch({}, (err, stats) => next(err, stats));
 
     function finish(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), false);
       done();
     }
 
     function thirdPass(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
       const { errors } = stats.compilation;
-      expect(errors).toHaveLength(1);
+      assert.strictEqual(errors.length, 1);
       const [{ message }] = errors;
-      expect(message).toEqual(expect.stringMatching("entry.scss"));
-      expect(message).not.toEqual(expect.stringMatching("leaf.scss"));
+      assert.match(message, /entry.scss/u);
+      assert.doesNotMatch(message, /leaf.scss/u);
 
       next = finish;
       writeFileSync(target, "#bar { background: #000000; }\n");
     }
 
     function secondPass(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
       const { errors } = stats.compilation;
-      expect(errors).toHaveLength(1);
+      assert.strictEqual(errors.length, 1);
       const [{ message }] = errors;
-      expect(message).toEqual(expect.stringMatching("entry.scss"));
-      expect(message).toEqual(expect.stringMatching("leaf.scss"));
+      assert.match(message, /entry.scss/u);
+      assert.match(message, /leaf.scss/u);
 
       next = thirdPass;
       writeFileSync(target2, "#bar { background: #000000; }\n");
     }
 
     function firstPass(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
       const { errors } = stats.compilation;
-      expect(errors).toHaveLength(1);
+      assert.strictEqual(errors.length, 1);
       const [{ message }] = errors;
-      expect(message).toEqual(expect.stringMatching("entry.scss"));
-      expect(message).not.toEqual(expect.stringMatching("leaf.scss"));
+      assert.match(message, /entry.scss/u);
+      assert.doesNotMatch(message, /leaf.scss/u);
 
       next = secondPass;
       writeFileSync(target2, "#bar { background: black; }\n");

--- a/test/symbols.test.js
+++ b/test/symbols.test.js
@@ -1,14 +1,10 @@
+import assert from "node:assert/strict";
 import { join } from "node:path";
+import { describe, it } from "node:test";
 
-import { jest } from "@jest/globals";
-
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 describe("symbols", () => {
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   it("should return error", async () => {
     const compiler = pack(
       "symbols",
@@ -17,7 +13,7 @@ describe("symbols", () => {
     );
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(false);
-    expect(stats.hasErrors()).toBe(true);
+    assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), true);
   });
 });

--- a/test/threads.test.js
+++ b/test/threads.test.js
@@ -1,5 +1,8 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import workerThreads from "node:worker_threads";
-import pack from "./utils/pack";
+
+import pack from "./utils/pack.js";
 
 describe("Multithread", () => {
   let workerCount;
@@ -25,8 +28,8 @@ describe("Multithread", () => {
 
     const stats = await compiler.runAsync();
 
-    expect(stats.hasErrors()).toBe(false);
-    expect(workerCount).toBeGreaterThanOrEqual(2);
+    assert.strictEqual(stats.hasErrors(), false);
+    assert.ok(workerCount >= 2);
   });
 
   it("should not spawn worker threads with concurrency=off", async () => {
@@ -34,7 +37,7 @@ describe("Multithread", () => {
 
     const stats = await compiler.runAsync();
 
-    expect(stats.hasErrors()).toBe(false);
-    expect(workerCount).toBe(0);
+    assert.strictEqual(stats.hasErrors(), false);
+    assert.strictEqual(workerCount, 0);
   });
 });

--- a/test/unified/unified.test.js
+++ b/test/unified/unified.test.js
@@ -1,12 +1,11 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { describe, it, mock } from "node:test";
 
-import { jest } from "@jest/globals";
+import LintPlugin from "../../src/index.js";
 
-import { existsSync, readFileSync } from "fs-extra";
-
-import LintPlugin from "../../src";
-
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 const eslint = {
   use: "eslint",
@@ -26,21 +25,24 @@ const linters = [eslint, stylelint];
 
 describe("unified plugin", () => {
   it("should require at least one linter", () => {
-    expect(() => new LintPlugin()).toThrow("options misses the property");
-    expect(() => new LintPlugin({ linters: [] })).toThrow(
-      "options.linters should be a non-empty array",
+    assert.throws(() => new LintPlugin(), /options misses the property/u);
+    assert.throws(
+      () => new LintPlugin({ linters: [] }),
+      /options\.linters should be a non-empty array/u,
     );
   });
 
   it("should reject a linter it does not know", () => {
-    expect(() => new LintPlugin({ linters: [{ use: "prettier" }] })).toThrow(
-      "unknown linter 'prettier'",
+    assert.throws(
+      () => new LintPlugin({ linters: [{ use: "prettier" }] }),
+      /unknown linter 'prettier'/u,
     );
   });
 
   it("should reject an adapter that cannot lint", () => {
-    expect(() => new LintPlugin({ linters: [{ use: { name: "x" } }] })).toThrow(
-      "a `name` and a `create` function",
+    assert.throws(
+      () => new LintPlugin({ linters: [{ use: { name: "x" } }] }),
+      /a `name` and a `create` function/u,
     );
   });
 
@@ -52,17 +54,17 @@ describe("unified plugin", () => {
       ...stats.compilation.warnings,
     ].map(({ message }) => message);
 
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.hasWarnings()).toBe(true);
-    expect(messages.join("\n")).toEqual(expect.stringMatching("bad.js"));
-    expect(messages.join("\n")).toEqual(expect.stringMatching("bad.scss"));
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.strictEqual(stats.hasWarnings(), true);
+    assert.match(messages.join("\n"), /bad.js/u);
+    assert.match(messages.join("\n"), /bad.scss/u);
   });
 
   it("should lint nothing to report when every file is fine", async () => {
     const compiler = pack("good", { linters });
     const stats = await compiler.runAsync();
-    expect(stats.hasErrors()).toBe(false);
-    expect(stats.hasWarnings()).toBe(false);
+    assert.strictEqual(stats.hasErrors(), false);
+    assert.strictEqual(stats.hasWarnings(), false);
   });
 
   it("should run a linter given no options of its own", async () => {
@@ -73,10 +75,8 @@ describe("unified plugin", () => {
     });
     const stats = await compiler.runAsync();
 
-    expect(stats.hasErrors()).toBe(true);
-    expect(stats.compilation.errors[0].message).toEqual(
-      expect.stringMatching("bad.scss"),
-    );
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.match(stats.compilation.errors[0].message, /bad.scss/u);
   });
 
   it("should let a linter override a shared option", async () => {
@@ -87,8 +87,8 @@ describe("unified plugin", () => {
     const stats = await compiler.runAsync();
     const [error] = stats.compilation.errors;
 
-    expect(stats.compilation.errors).toHaveLength(1);
-    expect(error.message).toEqual(expect.stringMatching("bad.scss"));
+    assert.strictEqual(stats.compilation.errors.length, 1);
+    assert.match(error.message, /bad.scss/u);
   });
 
   it("should run the same linter more than once", async () => {
@@ -101,12 +101,12 @@ describe("unified plugin", () => {
     const stats = await compiler.runAsync();
     const messages = stats.compilation.errors.map(({ message }) => message);
 
-    expect(messages).toHaveLength(1);
-    expect(messages[0]).toEqual(expect.stringMatching("bad.js"));
+    assert.strictEqual(messages.length, 1);
+    assert.match(messages[0], /bad.js/u);
   });
 
   it("should run a linter shipped outside this package", async () => {
-    const lintFiles = jest.fn().mockResolvedValue([{ file: "checked" }]);
+    const lintFiles = mock.fn(async () => [{ file: "checked" }]);
     const compiler = pack("good", {
       linters: [
         {
@@ -125,8 +125,9 @@ describe("unified plugin", () => {
     });
     const stats = await compiler.runAsync();
 
-    expect(lintFiles).toHaveBeenCalled();
-    expect(stats.compilation.errors[0].message).toBe(
+    assert.ok(lintFiles.mock.callCount() > 0);
+    assert.strictEqual(
+      stats.compilation.errors[0].message,
       "[made-up] made up problem",
     );
   });
@@ -134,7 +135,7 @@ describe("unified plugin", () => {
   it("should fail the build when a shared failOnError is set", async () => {
     const compiler = pack("both", { failOnError: true, linters });
 
-    await expect(compiler.runAsync()).rejects.toThrow("bad.js");
+    await assert.rejects(compiler.runAsync(), /bad\.js/u);
   });
 
   it("should join the reports of every linter into one output report", async () => {
@@ -146,17 +147,15 @@ describe("unified plugin", () => {
 
     await compiler.runAsync();
 
-    expect(existsSync(filePath)).toBe(true);
+    assert.strictEqual(existsSync(filePath), true);
 
     const [eslintReport, stylelintReport] = readFileSync(filePath, "utf8")
       .split("\n")
       .map((report) => JSON.parse(report));
 
-    expect(eslintReport).toMatchObject([
-      { filePath: expect.stringContaining("bad.js") },
-    ]);
-    expect(stylelintReport).toMatchObject([
-      { source: expect.stringContaining("bad.scss") },
-    ]);
+    assert.strictEqual(eslintReport.length, 1);
+    assert.ok(eslintReport[0].filePath.includes("bad.js"));
+    assert.strictEqual(stylelintReport.length, 1);
+    assert.ok(stylelintReport[0].source.includes("bad.scss"));
   });
 });

--- a/test/unified/utils/conf.js
+++ b/test/unified/utils/conf.js
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import LintPlugin from "../../../src";
+import LintPlugin from "../../../src/index.js";
 
 export default (context, pluginConf = {}, webpackConf = {}) => {
   const testDir = join(import.meta.dirname, "..");

--- a/test/unified/utils/pack.js
+++ b/test/unified/utils/pack.js
@@ -1,6 +1,6 @@
 import webpack from "webpack";
 
-import conf from "./conf";
+import conf from "./conf.js";
 
 export default (context, pluginConf = {}, webpackConf = {}) => {
   const compiler = webpack(conf(context, pluginConf, webpackConf));

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,79 +1,52 @@
-import { jest } from "@jest/globals";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { describe, it } from "node:test";
 
-jest.unstable_mockModule("node:fs", () => ({
-  statSync(pattern) {
-    return {
-      isDirectory() {
-        return pattern.indexOf("/path/") === 0;
-      },
-    };
-  },
-}));
+import { parseFiles, parseFoldersToGlobs } from "../src/utils.js";
 
-const { parseFiles, parseFoldersToGlobs } = await import("../src/utils.js");
+// `parseFoldersToGlobs` stats what it is given, so the fixtures have to exist.
+const directory = join(import.meta.dirname, "fixtures");
+const file = join(import.meta.dirname, "fixtures", "good.js");
 
 describe("utils", () => {
   it("parseFiles should return relative files from context", () => {
-    expect(
-      parseFiles(
-        ["**/*", "../package-a/src/**/", "../package-b/src/**/"],
-        "main/src",
-      ),
-    ).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("main/src/**/*"),
-        expect.stringContaining("main/package-a/src/**"),
-        expect.stringContaining("main/package-b/src/**"),
-      ]),
+    const [all, packageA, packageB] = parseFiles(
+      ["**/*", "../package-a/src/**/", "../package-b/src/**/"],
+      "main/src",
     );
+
+    assert.ok(all.endsWith("main/src/**/*"));
+    assert.ok(packageA.endsWith("main/package-a/src/**"));
+    assert.ok(packageB.endsWith("main/package-b/src/**"));
   });
 
   it("parseFoldersToGlobs should return globs for folders", () => {
-    const withoutSlash = "/path/to/code";
-    const withSlash = `${withoutSlash}/`;
+    assert.deepStrictEqual(parseFoldersToGlobs(directory, "js"), [
+      `${directory}/**/*.js`,
+    ]);
+    assert.deepStrictEqual(parseFoldersToGlobs(`${directory}/`, "js"), [
+      `${directory}/**/*.js`,
+    ]);
 
-    expect(parseFoldersToGlobs(withoutSlash, "js")).toMatchInlineSnapshot(`
-    [
-      "/path/to/code/**/*.js",
-    ]
-  `);
-    expect(parseFoldersToGlobs(withSlash, "js")).toMatchInlineSnapshot(`
-    [
-      "/path/to/code/**/*.js",
-    ]
-  `);
-
-    expect(
+    assert.deepStrictEqual(
       parseFoldersToGlobs(
-        [withoutSlash, withSlash, "/some/file.js"],
+        [directory, `${directory}/`, file],
         ["js", "cjs", "mjs"],
       ),
-    ).toMatchInlineSnapshot(`
-    [
-      "/path/to/code/**/*.{js,cjs,mjs}",
-      "/path/to/code/**/*.{js,cjs,mjs}",
-      "/some/file.js",
-    ]
-  `);
+      [
+        `${directory}/**/*.{js,cjs,mjs}`,
+        `${directory}/**/*.{js,cjs,mjs}`,
+        file,
+      ],
+    );
 
-    expect(parseFoldersToGlobs(withoutSlash)).toMatchInlineSnapshot(`
-    [
-      "/path/to/code/**",
-    ]
-  `);
-
-    expect(parseFoldersToGlobs(withSlash)).toMatchInlineSnapshot(`
-    [
-      "/path/to/code/**",
-    ]
-  `);
+    assert.deepStrictEqual(parseFoldersToGlobs(directory), [`${directory}/**`]);
+    assert.deepStrictEqual(parseFoldersToGlobs(`${directory}/`), [
+      `${directory}/**`,
+    ]);
   });
 
   it("parseFoldersToGlobs should return unmodified globs for globs (ignoring extensions)", () => {
-    expect(parseFoldersToGlobs("**.notjs", "js")).toMatchInlineSnapshot(`
-    [
-      "**.notjs",
-    ]
-  `);
+    assert.deepStrictEqual(parseFoldersToGlobs("**.notjs", "js"), ["**.notjs"]);
   });
 });

--- a/test/utils/conf.js
+++ b/test/utils/conf.js
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import LintPlugin from "../../src";
+import LintPlugin from "../../src/index.js";
 
 // Options the plugin only accepts next to the linter groups, not inside one.
 const PLUGIN_OPTIONS = ["context", "lintDirtyModulesOnly"];

--- a/test/utils/pack.js
+++ b/test/utils/pack.js
@@ -1,6 +1,6 @@
 import webpack from "webpack";
 
-import conf from "./conf";
+import conf from "./conf.js";
 
 /**
  * new a test webpack compiler

--- a/test/warning.test.js
+++ b/test/warning.test.js
@@ -1,11 +1,14 @@
-import pack from "./utils/pack";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
 
 describe("warning", () => {
   it("should emit warnings", async () => {
     const compiler = pack("warn");
 
     const stats = await compiler.runAsync();
-    expect(stats.hasWarnings()).toBe(true);
-    expect(stats.hasErrors()).toBe(false);
+    assert.strictEqual(stats.hasWarnings(), true);
+    assert.strictEqual(stats.hasErrors(), false);
   });
 });

--- a/test/watch.test.js
+++ b/test/watch.test.js
@@ -1,15 +1,13 @@
-import { writeFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
 
-import { removeSync } from "fs-extra";
-
-import pack from "./utils/pack";
+import pack from "./utils/pack.js";
 
 const target = join(import.meta.dirname, "fixtures", "watch-entry.js");
 const target2 = join(import.meta.dirname, "fixtures", "watch-leaf.js");
-const targetExpectedPattern = expect.stringMatching(
-  target.replaceAll("\\", "\\\\"),
-);
+const targetPattern = new RegExp(target.replaceAll("\\", "\\\\"), "u");
 
 describe("watch", () => {
   let watch;
@@ -18,22 +16,22 @@ describe("watch", () => {
     if (watch) {
       watch.close();
     }
-    removeSync(target);
-    removeSync(target2);
+    rmSync(target, { force: true, recursive: true });
+    rmSync(target2, { force: true, recursive: true });
   });
 
-  it("should watch", (done) => {
+  it("should watch", (t, done) => {
     const compiler = pack("good");
 
     watch = compiler.watch({}, (err, stats) => {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), false);
       done();
     });
   });
 
-  it("should watch with unique messages", (done) => {
+  it("should watch with unique messages", (t, done) => {
     writeFileSync(target, "var foo = stuff\n");
 
     // eslint-disable-next-line no-use-before-define
@@ -42,24 +40,24 @@ describe("watch", () => {
     watch = compiler.watch({}, (err, stats) => next(err, stats));
 
     function finish(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(false);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), false);
       done();
     }
 
     function thirdPass(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
       const { errors } = stats.compilation;
-      expect(errors).toHaveLength(1);
+      assert.strictEqual(errors.length, 1);
       const [{ message }] = errors;
-      expect(message).toEqual(targetExpectedPattern);
-      expect(message).toEqual(expect.stringMatching("no-unused-vars"));
+      assert.match(message, targetPattern);
+      assert.match(message, /no-unused-vars/u);
       // `prefer-const` fails here
-      expect(message).toEqual(expect.stringMatching("prefer-const"));
-      expect(message).toEqual(expect.stringMatching("\\(4 errors,"));
+      assert.match(message, /prefer-const/u);
+      assert.match(message, /\(4 errors,/u);
 
       next = finish;
 
@@ -70,17 +68,17 @@ describe("watch", () => {
     }
 
     function secondPass(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
       const { errors } = stats.compilation;
-      expect(errors).toHaveLength(1);
+      assert.strictEqual(errors.length, 1);
       const [{ message }] = errors;
-      expect(message).toEqual(targetExpectedPattern);
-      expect(message).toEqual(expect.stringMatching("no-unused-vars"));
+      assert.match(message, targetPattern);
+      assert.match(message, /no-unused-vars/u);
       // `prefer-const` passes here
-      expect(message).toEqual(expect.stringMatching("prefer-const"));
-      expect(message).toEqual(expect.stringMatching("\\(4 errors,"));
+      assert.match(message, /prefer-const/u);
+      assert.match(message, /\(4 errors,/u);
 
       next = thirdPass;
 
@@ -91,14 +89,14 @@ describe("watch", () => {
     }
 
     function firstPass(err, stats) {
-      expect(err).toBeNull();
-      expect(stats.hasWarnings()).toBe(false);
-      expect(stats.hasErrors()).toBe(true);
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasWarnings(), false);
+      assert.strictEqual(stats.hasErrors(), true);
       const { errors } = stats.compilation;
-      expect(errors).toHaveLength(1);
+      assert.strictEqual(errors.length, 1);
       const [{ message }] = errors;
-      expect(message).toEqual(targetExpectedPattern);
-      expect(message).toEqual(expect.stringMatching("\\(3 errors,"));
+      assert.match(message, targetPattern);
+      assert.match(message, /\(3 errors,/u);
 
       next = secondPass;
 

--- a/types/linters/stylelint-worker.d.cts
+++ b/types/linters/stylelint-worker.d.cts
@@ -17,4 +17,7 @@ export function lintFiles(files: string | string[]): Promise<LintResult[]>;
  * @param {Options} options the worker options
  * @param {Partial<StylelintOptions>} stylelintOptions the stylelint options
  */
-export function setup(options: Options, stylelintOptions: Partial<StylelintOptions>): void;
+export function setup(
+  options: Options,
+  stylelintOptions: Partial<StylelintOptions>,
+): void;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The suite runs on the test runner Node ships, so `jest`, `@jest/globals` and `jest.config.js` go away. `describe`/`it` and the lifecycle hooks come from `node:test`, assertions from `node:assert/strict`, and coverage from `--experimental-test-coverage` written as lcov for codecov. Node.js 20 is end-of-life, so `engines.node` moves to the oldest maintained LTS, `>= 22.12.0`.

Nothing in `src/` changed. Four things in the diff are worth a reviewer's attention:

- **`assert.rejects(promise, "text")` reads the string as the assertion's own message, not as a matcher.** Every `.rejects.toThrow("…")` and `.toThrow("…")` became a regex instead, so those 11 assertions still check what they used to rather than passing on any rejection at all.
- **The suite ran through babel under jest, and now runs as written.** Relative imports needed explicit extensions, and `fs-extra`'s named exports do not survive native ESM interop — `copySync`/`removeSync` are `node:fs`'s `cpSync`/`rmSync`, so `fs-extra` and `@types/fs-extra` are gone too.
- **`eslint-config-webpack` scopes its test-file rule relaxations behind having `jest` as a dependency**, so removing jest turned `id-length`, `jsdoc/require-jsdoc` and the `n/no-unsupported-features/*` rules back on for `test/**`. `eslint.config.mjs` now carries that same set itself.
- **`utils` mocked `node:fs` through `jest.unstable_mockModule`.** It stats real fixture paths now instead, which is what the mock was standing in for.

**What kind of change does this PR introduce?**

build (breaking).

**Did you add tests for your changes?**

No new tests — the suite is the subject of the change. All 60 files are ported: 124 passing and the 2 ESLint 10 eslintrc suites skipped, the same counts as on `main`, with coverage at 99.33% of lines.

**Does this PR introduce a breaking change?**

Yes. Node.js 20 is no longer supported; the minimum is `>= 22.12.0`. Node 20 reached end-of-life in April 2026, and the CI matrix drops to 22.x and 24.x.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The README's support note names the Node.js requirement. A changeset is included marking this a major.

**Use of AI**

Written with Claude Code, driven interactively. I asked for the migration and the version bump; Claude did the conversion, found the `assert.rejects` message-vs-matcher trap and the jest-gated lint config, and reported both. I reviewed the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy)_