### PR TITLE
feat: apply ESLint bulk suppressions below ESLint 10

### DIFF
--- a/.changeset/document-eslint-suppressions.md
+++ b/.changeset/document-eslint-suppressions.md
@@ -1,5 +1,5 @@
 ---
-"diagnostics-webpack-plugin": patch
+"diagnostics-webpack-plugin": minor
 ---
 
-Documented ESLint bulk suppressions. `applySuppressions` and `suppressionsLocation` reach the `ESLint` class through the usual pass-through and need ESLint 10, which is where they became constructor options.
+Added ESLint bulk suppressions. `applySuppressions` and `suppressionsLocation` reach the `ESLint` class as they are on ESLint 10, and on ESLint 9.24 and later the plugin applies the suppressions itself, since ESLint only wires them into its CLI there.

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ If the `eslintPath` is a folder like the official ESLint, or you specify a `form
 
 ### Suppressions
 
-[Bulk suppressions](https://eslint.org/docs/latest/use/suppressions) work through the same pass-through: enable ESLint's own `applySuppressions`, and point `suppressionsLocation` at the file if it is not the default `eslint-suppressions.json`.
+[Bulk suppressions](https://eslint.org/docs/latest/use/suppressions) are supported: enable ESLint's own `applySuppressions`, and point `suppressionsLocation` at the file if it is not the default `eslint-suppressions.json`.
 
 ```js
 new DiagnosticsPlugin({
@@ -392,7 +392,7 @@ new DiagnosticsPlugin({
 > });
 > ```
 
-This needs ESLint 10. ESLint 9 has suppressions in its CLI only, and rejects the option with `Invalid Options: - Unknown options: applySuppressions`.
+Suppressions need ESLint 9.24 or later. ESLint 10 takes both options itself; below that they reach its CLI alone, so the plugin applies the suppressions after linting instead — the same file, the same paths, the same result.
 
 ## Stylelint
 

--- a/src/checks/eslint.js
+++ b/src/checks/eslint.js
@@ -1,12 +1,13 @@
 import { createRequire } from "node:module";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 
 import { importFrom, omitPluginOptions } from "../utils.js";
 
 // JSON is read through CommonJS: import attributes are still ahead of the tooling
-const schemaRequire = createRequire(import.meta.url);
-const pluginSchema = schemaRequire("../options.json");
-const sharedSchema = schemaRequire("../shared-options.json");
-const schema = schemaRequire("./eslint.json");
+const nodeRequire = createRequire(import.meta.url);
+const pluginSchema = nodeRequire("../options.json");
+const sharedSchema = nodeRequire("../shared-options.json");
+const schema = nodeRequire("./eslint.json");
 
 /** @typedef {import("eslint").ESLint} ESLint */
 /** @typedef {import("eslint").ESLint.Formatter} Formatter */
@@ -16,7 +17,10 @@ const schema = schemaRequire("./eslint.json");
 /** @typedef {import("../checks/index.js").CheckContext} CheckContext */
 /** @typedef {import("../checks/index.js").CheckInstance} CheckInstance */
 /** @typedef {import("../options.js").CheckOptions} Options */
-/** @typedef {{ new (arg0: ESLintOptions): ESLint, outputFixes: (arg0: LintResult[]) => Promise<void> }} ESLintClass */
+/** @typedef {{ new (arg0: ESLintOptions): ESLint, outputFixes: (arg0: LintResult[]) => Promise<void>, version: string }} ESLintClass */
+
+// ESLint 9 hardcodes this in its CLI; only ESLint 10 exposes it on the service.
+const DEFAULT_SUPPRESSIONS_FILE = "eslint-suppressions.json";
 
 // `fix` and `extensions` are meaningful to ESLint itself, the rest of the
 // plugin schema is not.
@@ -49,6 +53,47 @@ async function removeIgnoredWarnings(eslint, results) {
   return /** @type {LintResult[]} */ (
     (await Promise.all(filterPromises)).filter((result) => result !== false)
   );
+}
+
+/**
+ * ESLint 10 applies suppressions itself; 9 ships the same service but wires it
+ * into its CLI alone, so the plugin drives it the way ESLint 10 would.
+ * @param {string} specifier the `eslintPath`, or `eslint`
+ * @param {ESLintOptions} eslintOptions the options ESLint was given
+ * @returns {(results: LintResult[]) => Promise<LintResult[]>} drops suppressed messages
+ */
+function createSuppressionsFilter(specifier, eslintOptions) {
+  const manifest =
+    isAbsolute(specifier) || specifier.startsWith(".")
+      ? join(specifier, "package.json")
+      : `${specifier}/package.json`;
+
+  let SuppressionsService;
+
+  try {
+    // `exports` hides the service, so it is read by path rather than specifier.
+    ({ SuppressionsService } = nodeRequire(
+      join(
+        dirname(nodeRequire.resolve(manifest)),
+        "lib/services/suppressions-service.js",
+      ),
+    ));
+  } catch (error) {
+    throw new Error(
+      "`applySuppressions` needs ESLint 9.24 or later, and the ESLint in use does not ship suppressions.",
+      { cause: error },
+    );
+  }
+
+  const cwd = eslintOptions.cwd || process.cwd();
+  const filePath = resolve(
+    cwd,
+    eslintOptions.suppressionsLocation || DEFAULT_SUPPRESSIONS_FILE,
+  );
+  const suppressions = new SuppressionsService({ cwd, filePath });
+
+  return async (results) =>
+    suppressions.applySuppressions(results, await suppressions.load()).results;
 }
 
 /**
@@ -106,13 +151,26 @@ function getESLintOptions(options) {
 async function create({ options }) {
   const eslintOptions = getESLintOptions(options);
   const fix = Boolean(eslintOptions.fix);
+  const specifier = options.eslintPath || "eslint";
 
-  const eslintModule = await importFrom(options.eslintPath || "eslint");
+  const eslintModule = await importFrom(specifier);
 
   /** @type {ESLintClass} */
   const ESLint = await eslintModule.loadESLint({
     useFlatConfig: options.configType === "flat",
   });
+
+  /** @type {((results: LintResult[]) => Promise<LintResult[]>) | undefined} */
+  let applySuppressions;
+
+  if (
+    eslintOptions.applySuppressions &&
+    Number.parseInt(ESLint.version, 10) < 10
+  ) {
+    applySuppressions = createSuppressionsFilter(specifier, eslintOptions);
+    delete eslintOptions.applySuppressions;
+    delete eslintOptions.suppressionsLocation;
+  }
 
   const eslint = new ESLint(eslintOptions);
 
@@ -127,8 +185,13 @@ async function create({ options }) {
 
       return results;
     },
-    getResults: (results) =>
-      removeIgnoredWarnings(eslint, /** @type {LintResult[]} */ (results)),
+    async getResults(results) {
+      const suppressed = applySuppressions
+        ? await applySuppressions(/** @type {LintResult[]} */ (results))
+        : /** @type {LintResult[]} */ (results);
+
+      return removeIgnoredWarnings(eslint, suppressed);
+    },
     splitResults(results) {
       /** @type {LintResult[]} */
       const errors = [];

--- a/test/fixtures/subdir/suppressed-error-entry.js
+++ b/test/fixtures/subdir/suppressed-error-entry.js
@@ -1,0 +1,1 @@
+require("./suppressed-error");

--- a/test/fixtures/subdir/suppressed-error.js
+++ b/test/fixtures/subdir/suppressed-error.js
@@ -1,0 +1,1 @@
+var foo = undefinedVariable;

--- a/test/suppressions.test.js
+++ b/test/suppressions.test.js
@@ -8,17 +8,14 @@ import { ESLint } from "eslint";
 import pack from "./utils/pack.js";
 
 const fixtures = join(import.meta.dirname, "fixtures");
+const subdirectory = join(fixtures, "subdir");
 const defaultLocation = join(fixtures, "eslint-suppressions.json");
 const customLocation = join(fixtures, "custom-suppressions.json");
 
-// ESLint resolves both the suppressions file and the paths inside it against
-// its own `cwd`, which is why every case sets one.
 const violations = {
-  "suppressed-error.js": {
-    "no-undef": { count: 1 },
-    "no-unused-vars": { count: 1 },
-    "no-var": { count: 1 },
-  },
+  "no-undef": { count: 1 },
+  "no-unused-vars": { count: 1 },
+  "no-var": { count: 1 },
 };
 
 /**
@@ -29,9 +26,10 @@ function writeSuppressions(filePath, suppressions) {
   writeFileSync(filePath, JSON.stringify(suppressions, null, 2));
 }
 
-// `applySuppressions` reached the ESLint constructor in v10; v9 has the
-// feature in its CLI only and rejects the option.
-const supported = Number.parseInt(ESLint.version, 10) >= 10;
+// Suppressions landed in ESLint 9.24, as a CLI feature; the plugin drives the
+// service itself below ESLint 10, which is where it became an option.
+const [major, minor] = ESLint.version.split(".").map(Number);
+const supported = major > 9 || (major === 9 && minor >= 24);
 
 (supported ? describe : describe.skip)("suppressions", () => {
   afterEach(() => {
@@ -52,7 +50,7 @@ const supported = Number.parseInt(ESLint.version, 10) >= 10;
   });
 
   it("should suppress the errors a suppressions file records", async () => {
-    writeSuppressions(defaultLocation, violations);
+    writeSuppressions(defaultLocation, { "suppressed-error.js": violations });
 
     const compiler = pack("suppressed-error", {
       applySuppressions: true,
@@ -66,7 +64,7 @@ const supported = Number.parseInt(ESLint.version, 10) >= 10;
   });
 
   it("should read the suppressions file named by suppressionsLocation", async () => {
-    writeSuppressions(customLocation, violations);
+    writeSuppressions(customLocation, { "suppressed-error.js": violations });
 
     const compiler = pack("suppressed-error", {
       applySuppressions: true,
@@ -77,6 +75,49 @@ const supported = Number.parseInt(ESLint.version, 10) >= 10;
     const stats = await compiler.runAsync();
 
     assert.strictEqual(stats.hasWarnings(), false);
+    assert.strictEqual(stats.hasErrors(), false);
+  });
+
+  it("should accept an absolute suppressionsLocation", async () => {
+    writeSuppressions(customLocation, { "suppressed-error.js": violations });
+
+    const compiler = pack("suppressed-error", {
+      applySuppressions: true,
+      cwd: fixtures,
+      suppressionsLocation: customLocation,
+    });
+
+    const stats = await compiler.runAsync();
+
+    assert.strictEqual(stats.hasErrors(), false);
+  });
+
+  it("should record a nested file under the path relative to cwd", async () => {
+    writeSuppressions(defaultLocation, {
+      "subdir/suppressed-error.js": violations,
+    });
+
+    const compiler = pack("subdir/suppressed-error", {
+      applySuppressions: true,
+      cwd: fixtures,
+    });
+
+    const stats = await compiler.runAsync();
+
+    assert.strictEqual(stats.hasErrors(), false);
+  });
+
+  it("should reach a suppressions file outside cwd", async () => {
+    writeSuppressions(defaultLocation, { "suppressed-error.js": violations });
+
+    const compiler = pack("subdir/suppressed-error", {
+      applySuppressions: true,
+      cwd: subdirectory,
+      suppressionsLocation: "../eslint-suppressions.json",
+    });
+
+    const stats = await compiler.runAsync();
+
     assert.strictEqual(stats.hasErrors(), false);
   });
 

--- a/types/checks/eslint.d.ts
+++ b/types/checks/eslint.d.ts
@@ -25,6 +25,7 @@ export type Options = import("../options.js").CheckOptions;
 export type ESLintClass = {
   new (arg0: ESLintOptions): ESLint;
   outputFixes: (arg0: LintResult[]) => Promise<void>;
+  version: string;
 };
 /**
  * @param {Options} options plugin options


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Closes #291. Supersedes #292, whose conflicts this carries forward instead.

[Bulk suppressions](https://eslint.org/docs/latest/use/suppressions) now work on every ESLint this plugin supports:

- **ESLint 10** takes `applySuppressions` and `suppressionsLocation` as constructor options, and the plugin already hands unrecognised ESLint options to the `ESLint` class as they are. Nothing needed.
- **ESLint 9.24 and later** ships the same `SuppressionsService` but wires it into its CLI alone, and the constructor rejects the options outright with `Invalid Options: - Unknown options: applySuppressions`. The plugin now drives the service itself after linting.
- **Below 9.24** the option raises an error naming the version it needs, rather than silently reporting the very violations the user recorded as suppressed.

The ESLint 9 path resolves the file and the paths recorded inside it against ESLint's `cwd`, and reads the default name `eslint-suppressions.json` when no location is given — the same rules ESLint 10 applies, so one config behaves identically on both and the tests run unmodified against each.

Two details behind that:

- **ESLint's `exports` hides the service**, so it is loaded by absolute path rather than by specifier. The package directory comes from resolving `eslint/package.json`, which respects `eslintPath` and works on Windows. #292 stripped `/lib/api.js` off the resolved entry with a POSIX-only regexp, so its fallback silently did nothing there.
- **`DEFAULT_SUPPRESSIONS_FILENAME` is an ESLint 10 addition.** ESLint 9 hardcodes the name in its CLI, so reading the constant gave `undefined` and a `paths[1] must be of type string` crash — caught only by running the suite against 9.

Credit for finding the bug and for the shape of these cases goes to @viddo.

**What kind of change does this PR introduce?**

feat.

**Did you add tests for your changes?**

Yes. `test/suppressions.test.js` covers eight cases: no file, the default file, a named `suppressionsLocation`, an absolute one, a nested file recorded relative to `cwd`, a suppressions file outside `cwd` reached with `../`, partial suppression that still reports the rest, and a location naming no file. They are gated at ESLint 9.24 and run on both majors — 132 passing on ESLint 10, 134 on ESLint 9 (the two eslintrc suites also run there). I checked they hold something: deleting `applySuppressions` from `getESLintOptions` turns three of them red on ESLint 10, and the ESLint 9 path was written against a failing suite.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The README's `Suppressions` section under `## ESLint` covers the options, the `cwd` caveat and the version requirement. The changeset is a minor.

**Use of AI**

Written with Claude Code, driven interactively. I asked it to fold #292 into this PR; it established that ESLint 10 makes #292's private-API module unnecessary, wrote the ESLint 9 fallback against the same service, and found the two portability defects above by running the suite on both majors. I reviewed the result.

> [!NOTE]
> The first commit of this PR reached `main` already, through #311's squash while this was stacked under it. What is left here is the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy