### PR TITLE
build: run the git hooks that were configured but dead

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/husky.config.js
+++ b/husky.config.js
@@ -1,6 +1,0 @@
-export default {
-  hooks: {
-    "pre-commit": "lint-staged",
-    "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-  },
-};

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:coverage": "cross-env NODE_ENV=test node --test --test-timeout=60000 --experimental-test-coverage --test-coverage-include=\"src/**\" --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=lcov.info \"test/**/*.test.js\"",
     "pretest": "npm run lint",
     "test": "npm run test:coverage",
-    "prepare": "npm run build",
+    "prepare": "husky && npm run build",
     "version": "changeset version",
     "release": "npm run build && changeset publish",
     "build:esm": "cross-env NODE_ENV=production babel src -d dist/esm --env-name esm --extensions \".js\" --copy-files --no-copy-ignored && node -e \"require('fs').writeFileSync('dist/esm/package.json','{\\\"type\\\": \\\"module\\\"}\\n')\"",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

No git hook has been running. `husky.config.js` is husky 4's format, husky 9 is what is installed, and husky 9 does not read that file — it reads `.husky/`, which did not exist. `core.hooksPath` was unset and `prepare` was `npm run build`, so husky was never invoked either. `lint-staged` and `commitlint` were installed, configured, and running on nothing.

This moves the two hooks `husky.config.js` declared into `.husky/`, drops the dead config, and makes `prepare` install them:

```
.husky/pre-commit   npx lint-staged
.husky/commit-msg   npx --no -- commitlint --edit "$1"
```

`prepare` becomes `husky && npm run build`. Verified `npm ci` still exits 0 with it, and that `husky` exits 0 where there is no `.git` — so an install from a tarball is unaffected. `.husky/_` is self-ignored by the `.gitignore` husky writes into it, so only the two hook scripts are tracked.

**What kind of change does this PR introduce?**

build.

**Did you add tests for your changes?**

Not a code change, but I exercised both hooks rather than assuming:

- a non-conventional message is rejected — `✖ type may not be empty`, `husky - commit-msg script failed (code 1)`
- a staged file with an unfixable lint error is rejected, and lint-staged reverts the tree — `husky - pre-commit script failed (code 1)`
- **editing a deliberately-broken fixture does not block a commit** — `test/fixtures/error.js` is covered by an ignore pattern, so ESLint reports it as a warning and the hook passes. Worth checking, since a hook that blocks work on the lint fixtures is a hook people disable
- this PR's own commit went through both hooks live

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — no changeset either: `prepare` does not run for consumers installing from npm, so nothing here reaches a user.

**Use of AI**

Written with Claude Code, driven interactively. I asked for the validation hooks to actually run; Claude found the husky 4/9 mismatch, wired the hooks up and tested all three cases above. I reviewed the result.

> [!NOTE]
> Each contributor picks this up on their next `npm install`; the hooks do not exist in a clone until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy)_