### PR TITLE
feat: validate the options from webpack's validate hook

### DIFF
--- a/.changeset/validate-from-the-webpack-hook.md
+++ b/.changeset/validate-from-the-webpack-hook.md
@@ -1,0 +1,5 @@
+---
+"diagnostics-webpack-plugin": minor
+---
+
+Option validation now runs from webpack's `compiler.hooks.validate`, so a mistake is reported where webpack validates the rest of the configuration and `validate: false` turns it off. Where webpack predates the hook, in 5.106, the plugin validates as it did before.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The plugin options have three layers:
 | [Shared](#shared-options) | Top level or in a `checks` entry | Which files are linted and how problems are reported. An entry overrides what it sets. |
 | Check                     | In a `checks` entry              | Options only that tool understands, plus everything its own Node.js API accepts.       |
 
+The options are checked against their schema from webpack's own [`validate`](https://webpack.js.org/configuration/other-options/#validate) hook, so a mistake is reported when webpack validates the rest of your configuration, and `validate: false` turns the check off along with webpack's.
+
 Every check to run is an entry in `checks`, named by its `use`. The list may name the same tool more than once, so one instance can inspect two file sets under different configurations.
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import globby from "globby";
 import micromatch from "micromatch";
 
 import createCheckRunner from "./check.js";
-import { getOptions } from "./options.js";
+import { getOptions, validateOptions } from "./options.js";
 import {
   arrify,
   parseFiles,
@@ -62,6 +62,7 @@ class DiagnosticsWebpackPlugin {
    */
   constructor(options = /** @type {Options} */ ({})) {
     this.key = LINT_PLUGIN;
+    this.given = options;
     this.options = getOptions(options);
     this.run = this.run.bind(this);
   }
@@ -75,16 +76,39 @@ class DiagnosticsWebpackPlugin {
     // this differentiates one from the other when being cached.
     this.key = compiler.name || `${this.key}_${(compilerId += 1)}`;
 
-    const context = this.getContext(compiler);
-    const checks = this.options.checks.map((check) =>
-      this.resolveCheck(compiler, context, check),
-    );
+    const validateGiven = () => {
+      validateOptions(compiler, this.given, this.options.checks);
+    };
+
+    // The hook, and webpack's `validate: false` with it, arrived in 5.106.
+    if (compiler.hooks.validate) {
+      compiler.hooks.validate.tap(this.key, validateGiven);
+    } else {
+      validateGiven();
+    }
+
+    /** @type {ResolvedCheck[] | undefined} */
+    let checks;
+
+    // Resolved on the first build rather than here, so that an option the
+    // schema rejects is reported by the hook above and not by this.
+    const getChecks = () => {
+      if (!checks) {
+        const context = this.getContext(compiler);
+
+        checks = this.options.checks.map((check) =>
+          this.resolveCheck(compiler, context, check),
+        );
+      }
+
+      return checks;
+    };
 
     // If `lintDirtyModulesOnly` is disabled,
     // execute the checks on the build
     if (!this.options.lintDirtyModulesOnly) {
       compiler.hooks.run.tapPromise(this.key, (compiler) =>
-        this.run(compiler, checks),
+        this.run(compiler, getChecks()),
       );
     }
 
@@ -92,7 +116,7 @@ class DiagnosticsWebpackPlugin {
 
     compiler.hooks.watchRun.tapPromise(this.key, (compiler) => {
       if (!hasCompilerRunByDirtyModule) {
-        return this.run(compiler, checks);
+        return this.run(compiler, getChecks());
       }
 
       hasCompilerRunByDirtyModule = false;

--- a/src/options.js
+++ b/src/options.js
@@ -12,6 +12,9 @@ const schemaRequire = createRequire(import.meta.url);
 const pluginSchema = schemaRequire("./options.json");
 const sharedSchema = schemaRequire("./shared-options.json");
 
+const PLUGIN_NAME = "Diagnostics Webpack Plugin";
+
+/** @typedef {import("webpack").Compiler} Compiler */
 /** @typedef {import("./checks/index.js").FormatterOption} FormatterOption */
 /** @typedef {import("./checks/index.js").CheckAdapter} CheckAdapter */
 /** @typedef {import("./checks/index.js").CheckAdapterInput} CheckAdapterInput */
@@ -108,7 +111,7 @@ function toAdapter(use) {
   if (typeof use !== "string") {
     if (!use || typeof use.create !== "function" || !use.name) {
       throw new Error(
-        "Diagnostics Webpack Plugin: `use` needs the name of a built-in check or a check adapter with a `name` and a `create` function.",
+        `${PLUGIN_NAME}: \`use\` needs the name of a built-in check or a check adapter with a \`name\` and a \`create\` function.`,
       );
     }
 
@@ -126,7 +129,7 @@ function toAdapter(use) {
 
   if (!adapter) {
     throw new Error(
-      `Diagnostics Webpack Plugin: unknown check '${use}', expected one of ${[
+      `${PLUGIN_NAME}: unknown check '${use}', expected one of ${[
         ...adapters.keys(),
       ]
         .map((name) => `'${name}'`)
@@ -144,33 +147,16 @@ function toAdapter(use) {
  * @returns {NormalizedOptions} normalized plugin options
  */
 function getOptions(pluginOptions) {
-  validate(/** @type {EXPECTED_ANY} */ (schema), pluginOptions, {
-    name: "Diagnostics Webpack Plugin",
-    baseDataPath: "options",
-  });
-
   const {
     context,
     lintDirtyModulesOnly,
-    checks: entries,
+    checks: entries = [],
     ...shared
   } = pluginOptions;
 
-  const enabled = entries.map((entry, index) => {
+  const enabled = entries.map((entry) => {
     const { use, ...own } = entry;
     const adapter = toAdapter(use);
-
-    validate(
-      /** @type {EXPECTED_ANY} */ ({
-        ...entrySchema,
-        properties: { ...entrySchema.properties, ...adapter.schema.properties },
-      }),
-      entry,
-      {
-        name: `Diagnostics Webpack Plugin (${adapter.label})`,
-        baseDataPath: `options.checks[${index}]`,
-      },
-    );
 
     /** @type {CheckOptions} */
     const options = {
@@ -191,4 +177,47 @@ function getOptions(pluginOptions) {
   return { context, lintDirtyModulesOnly, checks: enabled };
 }
 
-export { getOptions, schema };
+/**
+ * Runs from `compiler.hooks.validate`, so webpack's own `validate: false`
+ * turns it off the way it does for webpack's plugins.
+ * @param {Compiler} compiler compiler
+ * @param {Options} pluginOptions the options as they were given
+ * @param {EnabledCheck[]} checks the checks resolved from them
+ * @returns {void}
+ */
+function validateOptions(compiler, pluginOptions, checks) {
+  // `compiler.validate` arrived with the hook, in webpack 5.106.
+  const check = compiler.validate
+    ? compiler.validate.bind(compiler)
+    : /** @type {typeof compiler.validate} */ (
+        (schemaToUse, value, options) =>
+          validate(
+            /** @type {EXPECTED_ANY} */ (schemaToUse),
+            /** @type {EXPECTED_ANY} */ (value),
+            options,
+          )
+      );
+
+  check(/** @type {EXPECTED_ANY} */ (schema), pluginOptions, {
+    name: PLUGIN_NAME,
+    baseDataPath: "options",
+  });
+
+  for (const [index, entry] of (pluginOptions.checks || []).entries()) {
+    const { adapter } = checks[index];
+
+    check(
+      /** @type {EXPECTED_ANY} */ ({
+        ...entrySchema,
+        properties: { ...entrySchema.properties, ...adapter.schema.properties },
+      }),
+      entry,
+      {
+        name: `${PLUGIN_NAME} (${adapter.label})`,
+        baseDataPath: `options.checks[${index}]`,
+      },
+    );
+  }
+}
+
+export { getOptions, schema, validateOptions };

--- a/test/unified/unified.test.js
+++ b/test/unified/unified.test.js
@@ -25,12 +25,44 @@ const checks = [eslint, stylelint];
 
 describe("unified plugin", () => {
   it("should require at least one check", () => {
+    assert.throws(() => pack("good"), /options misses the property/u);
     assert.throws(
-      () => new DiagnosticsPlugin(),
-      /options misses the property/u,
+      () => pack("good", { checks: [] }),
+      /options\.checks should be a non-empty array/u,
     );
+  });
+
+  it("should reject an option the check does not understand", () => {
     assert.throws(
-      () => new DiagnosticsPlugin({ checks: [] }),
+      () => pack("good", { checks: [{ use: "eslint", extensions: 42 }] }),
+      /options\.checks\[0\]\.extensions should be one of these/u,
+    );
+  });
+
+  it("should validate nothing when webpack's validate is off", () => {
+    assert.doesNotThrow(() =>
+      pack("good", { checks: [] }, { validate: false }),
+    );
+    assert.doesNotThrow(() =>
+      pack(
+        "good",
+        { checks: [{ use: "eslint", extensions: 42 }] },
+        {
+          validate: false,
+        },
+      ),
+    );
+  });
+
+  it("should validate at once where webpack has no validate hook", () => {
+    // webpack below 5.106 has neither the hook nor `compiler.validate`.
+    const compiler = {
+      name: "no-validate-hook",
+      hooks: { run: { tapPromise() {} }, watchRun: { tapPromise() {} } },
+    };
+
+    assert.throws(
+      () => new DiagnosticsPlugin({ checks: [] }).apply(compiler),
       /options\.checks should be a non-empty array/u,
     );
   });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -36,6 +36,7 @@ declare class DiagnosticsWebpackPlugin {
    */
   constructor(options?: Options);
   key: string;
+  given: import("./options.js").Options;
   options: import("./options.js").NormalizedOptions;
   /**
    * @param {Compiler} compiler compiler

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,4 +1,5 @@
 export type EXPECTED_ANY = any;
+export type Compiler = import("webpack").Compiler;
 export type FormatterOption = import("./checks/index.js").FormatterOption;
 export type CheckAdapter = import("./checks/index.js").CheckAdapter;
 export type CheckAdapterInput = import("./checks/index.js").CheckAdapterInput;
@@ -133,3 +134,16 @@ export namespace schema {
   let properties: any;
   let required: string[];
 }
+/**
+ * Runs from `compiler.hooks.validate`, so webpack's own `validate: false`
+ * turns it off the way it does for webpack's plugins.
+ * @param {Compiler} compiler compiler
+ * @param {Options} pluginOptions the options as they were given
+ * @param {EnabledCheck[]} checks the checks resolved from them
+ * @returns {void}
+ */
+export function validateOptions(
+  compiler: Compiler,
+  pluginOptions: Options,
+  checks: EnabledCheck[],
+): void;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

webpack 5.106 added `compiler.hooks.validate`, and webpack's own plugins — `BannerPlugin`, `IgnorePlugin`, `ProgressPlugin`, `SourceMapDevToolPlugin` and the rest — tap it to check their options through `compiler.validate`. The plugin validated in its constructor instead, which meant it could not honour the one thing the hook exists for: `compiler.validate` returns immediately when `compiler.options.validate === false`, so the user's `validate: false` now turns the plugin's schema check off along with webpack's.

```js
compiler.hooks.validate.tap(this.key, () => {
  validateOptions(compiler, this.given, this.options.checks);
});
```

Both schema passes move together — the plugin schema and the per-entry one merged with the adapter's.

**One thing the change forced.** `apply` runs *before* `hooks.validate.call()`, so resolving each check eagerly in `apply` meant normalization reached a rejected value first: `{ use: "eslint", extensions: 42 }` threw `TypeError: extension.replace is not a function` rather than naming the option. Resolution is now deferred to the first build, past the hook, and the schema message is what surfaces.

Behaviour, measured on all four combinations:

| options | `validate` default | `validate: false` |
| :--- | :--- | :--- |
| `{}` | `options misses the property 'checks'` | builds |
| `{ checks: [] }` | `options.checks should be a non-empty array` | builds |
| `{ checks: [{ use: "eslint", extensions: 42 }] }` | `options.checks[0].extensions should be one of these` | builds |
| valid | builds | builds |

Schema errors now arrive from `webpack()` rather than from `new DiagnosticsPlugin()`. An unknown `use`, and an adapter without `name`/`create`, still throw at construction — the schema cannot express either, so they are not validation.

**`peerDependencies` stays at `webpack: ^5.0.0`.** Where the hook is absent the plugin validates from `apply` exactly as before, through `schema-utils` — 5.106 is a few weeks old and requiring it would be a steep toll for a lint plugin.

**What kind of change does this PR introduce?**

feat.

**Did you add tests for your changes?**

Yes, three in `test/unified/unified.test.js`: the rejected option value, `validate: false` skipping both a structural and a value error, and — with a stub compiler carrying no `validate` hook — the pre-5.106 path validating from `apply`. That last one is the only cover the fallback branch can get, since CI runs webpack 5.110. The two existing cases move from construction to build time. 135 passing; `src/index.js` and `src/options.js` are both at 100% of lines.

**Does this PR introduce a breaking change?**

Not for a released version — nothing has shipped under this name. Worth noting in review that anyone who caught a constructor throw would now catch it from `webpack()` instead.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

A line under `## Options` saying where validation runs and that `validate: false` covers it. The changeset is a minor.

**Use of AI**

Written with Claude Code, driven interactively. I pointed out webpack has a hook for this; Claude found `compiler.hooks.validate` and `compiler.validate`, made the change, and caught that `apply` running before the hook turned a schema error into a `TypeError` — which is why check resolution is deferred. I reviewed the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy)_