### PR TITLE
refactor: leave CommonJS to the lazy schema read

### DIFF
--- a/src/checks/eslint.js
+++ b/src/checks/eslint.js
@@ -1,13 +1,33 @@
+// eslint-disable-next-line jsdoc/reject-any-type
+/** @typedef {any} EXPECTED_ANY */
+
 import { createRequire } from "node:module";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { importFrom, omitPluginOptions } from "../utils.js";
 
-// JSON is read through CommonJS: import attributes are still ahead of the tooling
 const nodeRequire = createRequire(import.meta.url);
-const pluginSchema = nodeRequire("../options.json");
-const sharedSchema = nodeRequire("../shared-options.json");
-const schema = nodeRequire("./eslint.json");
+
+/** @type {{ plugin: EXPECTED_ANY, shared: EXPECTED_ANY, own: EXPECTED_ANY } | undefined} */
+let schemas;
+
+/**
+ * Read on demand, because a build that validates nothing never needs them.
+ * JSON is read through CommonJS: import attributes are still ahead of the tooling.
+ * @returns {{ plugin: EXPECTED_ANY, shared: EXPECTED_ANY, own: EXPECTED_ANY }} the schemas
+ */
+function getSchemas() {
+  if (!schemas) {
+    schemas = {
+      plugin: nodeRequire("../options.json"),
+      shared: nodeRequire("../shared-options.json"),
+      own: nodeRequire("./eslint.json"),
+    };
+  }
+
+  return schemas;
+}
 
 /** @typedef {import("eslint").ESLint} ESLint */
 /** @typedef {import("eslint").ESLint.Formatter} Formatter */
@@ -60,24 +80,23 @@ async function removeIgnoredWarnings(eslint, results) {
  * into its CLI alone, so the plugin drives it the way ESLint 10 would.
  * @param {string} specifier the `eslintPath`, or `eslint`
  * @param {ESLintOptions} eslintOptions the options ESLint was given
- * @returns {(results: LintResult[]) => Promise<LintResult[]>} drops suppressed messages
+ * @returns {Promise<(results: LintResult[]) => Promise<LintResult[]>>} drops suppressed messages
  */
-function createSuppressionsFilter(specifier, eslintOptions) {
+async function createSuppressionsFilter(specifier, eslintOptions) {
   const manifest =
     isAbsolute(specifier) || specifier.startsWith(".")
-      ? join(specifier, "package.json")
-      : `${specifier}/package.json`;
+      ? pathToFileURL(join(specifier, "package.json")).href
+      : import.meta.resolve(`${specifier}/package.json`);
 
   let SuppressionsService;
 
   try {
     // `exports` hides the service, so it is read by path rather than specifier.
-    ({ SuppressionsService } = nodeRequire(
-      join(
-        dirname(nodeRequire.resolve(manifest)),
-        "lib/services/suppressions-service.js",
-      ),
-    ));
+    const service = await import(
+      new URL("./lib/services/suppressions-service.js", manifest).href
+    );
+
+    ({ SuppressionsService } = service.default || service);
   } catch (error) {
     throw new Error(
       "`applySuppressions` needs ESLint 9.24 or later, and the ESLint in use does not ship suppressions.",
@@ -126,9 +145,9 @@ function getESLintOptions(options) {
     omitPluginOptions(
       options,
       {
-        ...pluginSchema.properties,
-        ...sharedSchema.properties,
-        ...schema.properties,
+        ...getSchemas().plugin.properties,
+        ...getSchemas().shared.properties,
+        ...getSchemas().own.properties,
       },
       KEPT_OPTIONS,
     )
@@ -167,7 +186,10 @@ async function create({ options }) {
     eslintOptions.applySuppressions &&
     Number.parseInt(ESLint.version, 10) < 10
   ) {
-    applySuppressions = createSuppressionsFilter(specifier, eslintOptions);
+    applySuppressions = await createSuppressionsFilter(
+      specifier,
+      eslintOptions,
+    );
     delete eslintOptions.applySuppressions;
     delete eslintOptions.suppressionsLocation;
   }
@@ -238,7 +260,9 @@ export default {
   name: "eslint",
   label: "ESLint",
   filesSource: "modules",
-  schema,
+  get schema() {
+    return getSchemas().own;
+  },
   defaults: {
     cache: true,
     cacheLocation:

--- a/src/checks/stylelint-worker.js
+++ b/src/checks/stylelint-worker.js
@@ -1,10 +1,4 @@
-"use strict";
-
-// eslint-disable-next-line jsdoc/reject-any-type
-/** @typedef {any} EXPECTED_ANY */
-
-const { isAbsolute } = require("node:path");
-const { pathToFileURL } = require("node:url");
+import { importFrom } from "../utils.js";
 
 /** @typedef {import("./stylelint.js").LintResult} LintResult */
 /** @typedef {import("./stylelint.js").StylelintOptions} StylelintOptions */
@@ -19,24 +13,6 @@ let linterOptions;
 
 /** @type {Promise<Stylelint> | null} */
 let stylelintPromise = null;
-
-/**
- * A package name is imported as it is; a path may name a directory or a
- * CommonJS entry, neither of which ESM resolves, so it is resolved first.
- * @param {string} specifier a module specifier or path
- * @returns {Promise<EXPECTED_ANY>} the imported module
- */
-async function importFrom(specifier) {
-  if (!specifier.startsWith(".") && !isAbsolute(specifier)) {
-    return import(specifier);
-  }
-
-  try {
-    return await import(pathToFileURL(require.resolve(specifier)).href);
-  } catch {
-    return import(specifier);
-  }
-}
 
 /**
  * Lazily load stylelint on first use.
@@ -89,4 +65,4 @@ async function lintFiles(files) {
   }));
 }
 
-module.exports = { getStylelint, lintFiles, setup };
+export { getStylelint, lintFiles, setup };

--- a/src/checks/stylelint.js
+++ b/src/checks/stylelint.js
@@ -1,5 +1,9 @@
+// eslint-disable-next-line jsdoc/reject-any-type
+/** @typedef {any} EXPECTED_ANY */
+
 import { createRequire } from "node:module";
 import { cpus } from "node:os";
+import { fileURLToPath } from "node:url";
 
 import { Worker as JestWorker } from "jest-worker";
 
@@ -9,18 +13,33 @@ import {
   parseFiles,
 } from "../utils.js";
 
-// JSON is read through CommonJS: import attributes are still ahead of the tooling
-const nodeRequire = createRequire(import.meta.url);
-const pluginSchema = nodeRequire("../options.json");
-const sharedSchema = nodeRequire("../shared-options.json");
-const schema = nodeRequire("./stylelint.json");
-
-// The worker entry stays CommonJS so every runner can load it in a worker thread
-const {
-  getStylelint: getStylelintInstance,
+import {
+  getStylelint as getStylelintInstance,
   lintFiles,
   setup,
-} = nodeRequire("./stylelint-worker.cjs");
+} from "./stylelint-worker.js";
+
+const nodeRequire = createRequire(import.meta.url);
+
+/** @type {{ plugin: EXPECTED_ANY, shared: EXPECTED_ANY, own: EXPECTED_ANY } | undefined} */
+let schemas;
+
+/**
+ * Read on demand, because a build that validates nothing never needs them.
+ * JSON is read through CommonJS: import attributes are still ahead of the tooling.
+ * @returns {{ plugin: EXPECTED_ANY, shared: EXPECTED_ANY, own: EXPECTED_ANY }} the schemas
+ */
+function getSchemas() {
+  if (!schemas) {
+    schemas = {
+      plugin: nodeRequire("../options.json"),
+      shared: nodeRequire("../shared-options.json"),
+      own: nodeRequire("./stylelint.json"),
+    };
+  }
+
+  return schemas;
+}
 
 /** @typedef {import("stylelint").Formatter} Formatter */
 /** @typedef {import("stylelint").FormatterType} FormatterType */
@@ -75,9 +94,9 @@ function getStylelintOptions(options) {
     omitPluginOptions(
       options,
       {
-        ...pluginSchema.properties,
-        ...sharedSchema.properties,
-        ...schema.properties,
+        ...getSchemas().plugin.properties,
+        ...getSchemas().shared.properties,
+        ...getSchemas().own.properties,
       },
       KEPT_OPTIONS,
     )
@@ -106,7 +125,7 @@ function loadStylelint(options) {
  * @returns {Loaded} loaded stylelint
  */
 function loadStylelintThreaded(cacheKey, poolSize, options) {
-  const source = nodeRequire.resolve("./stylelint-worker.cjs");
+  const source = fileURLToPath(import.meta.resolve("./stylelint-worker.js"));
   const local = loadStylelint(options);
 
   let worker = /** @type {Worker | null} */ (
@@ -302,7 +321,9 @@ export default {
   name: "stylelint",
   label: "Stylelint",
   filesSource: "glob",
-  schema,
+  get schema() {
+    return getSchemas().own;
+  },
   defaults: {
     cache: true,
     cacheLocation:

--- a/src/options.js
+++ b/src/options.js
@@ -8,9 +8,7 @@ import { validate } from "schema-utils";
 import adapters from "./checks/index.js";
 
 // JSON is read through CommonJS: import attributes are still ahead of the tooling
-const schemaRequire = createRequire(import.meta.url);
-const pluginSchema = schemaRequire("./options.json");
-const sharedSchema = schemaRequire("./shared-options.json");
+const nodeRequire = createRequire(import.meta.url);
 
 const PLUGIN_NAME = "Diagnostics Webpack Plugin";
 
@@ -81,25 +79,44 @@ const SHARED_DEFAULTS = {
 
 const DEFAULT_FOLDER_TO_EXCLUDE = "**/node_modules/**";
 
-const { use: useProperty, ...pluginProperties } = pluginSchema.properties;
+/** @type {{ schema: EXPECTED_ANY, entrySchema: EXPECTED_ANY } | undefined} */
+let schemas;
 
-const entrySchema = {
-  type: "object",
-  additionalProperties: true,
-  properties: { use: useProperty, ...sharedSchema.properties },
-  required: ["use"],
-};
+/**
+ * Read on demand, because a build that validates nothing never needs them.
+ * JSON is read through CommonJS: import attributes are still ahead of the tooling.
+ * @returns {{ schema: EXPECTED_ANY, entrySchema: EXPECTED_ANY }} the plugin schemas
+ */
+function getSchemas() {
+  if (!schemas) {
+    const pluginSchema = nodeRequire("./options.json");
+    const sharedSchema = nodeRequire("./shared-options.json");
+    const { use: useProperty, ...pluginProperties } = pluginSchema.properties;
 
-const schema = {
-  type: "object",
-  additionalProperties: false,
-  properties: {
-    ...pluginProperties,
-    ...sharedSchema.properties,
-    checks: { ...pluginProperties.checks, items: entrySchema },
-  },
-  required: ["checks"],
-};
+    const entrySchema = {
+      type: "object",
+      additionalProperties: true,
+      properties: { use: useProperty, ...sharedSchema.properties },
+      required: ["use"],
+    };
+
+    schemas = {
+      entrySchema,
+      schema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          ...pluginProperties,
+          ...sharedSchema.properties,
+          checks: { ...pluginProperties.checks, items: entrySchema },
+        },
+        required: ["checks"],
+      },
+    };
+  }
+
+  return schemas;
+}
 
 /**
  * A `use` is either the name of a built-in check or an adapter of its own, so
@@ -192,13 +209,15 @@ function validateOptions(compiler, pluginOptions, checks) {
     : /** @type {typeof compiler.validate} */ (
         (schemaToUse, value, options) =>
           validate(
-            /** @type {EXPECTED_ANY} */ (schemaToUse),
+            /** @type {EXPECTED_ANY} */ (
+              typeof schemaToUse === "function" ? schemaToUse() : schemaToUse
+            ),
             /** @type {EXPECTED_ANY} */ (value),
             options,
           )
       );
 
-  check(/** @type {EXPECTED_ANY} */ (schema), pluginOptions, {
+  check(() => getSchemas().schema, pluginOptions, {
     name: PLUGIN_NAME,
     baseDataPath: "options",
   });
@@ -207,10 +226,17 @@ function validateOptions(compiler, pluginOptions, checks) {
     const { adapter } = checks[index];
 
     check(
-      /** @type {EXPECTED_ANY} */ ({
-        ...entrySchema,
-        properties: { ...entrySchema.properties, ...adapter.schema.properties },
-      }),
+      () => {
+        const { entrySchema } = getSchemas();
+
+        return {
+          ...entrySchema,
+          properties: {
+            ...entrySchema.properties,
+            ...adapter.schema.properties,
+          },
+        };
+      },
       entry,
       {
         name: `${PLUGIN_NAME} (${adapter.label})`,
@@ -220,4 +246,4 @@ function validateOptions(compiler, pluginOptions, checks) {
   }
 }
 
-export { getOptions, schema, validateOptions };
+export { getOptions, validateOptions };

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,8 +56,8 @@ function arrify(value) {
 
 /**
  * A package name is imported as it is, so a test can still mock it. A path may
- * name a directory or a CommonJS entry, neither of which ESM resolves, so
- * CommonJS resolution finds the file first.
+ * name a directory, which `import.meta.resolve` returns unchanged for
+ * `import` to reject, so CommonJS resolution finds the entry file first.
  * @param {string} specifier a module specifier or path
  * @returns {Promise<EXPECTED_ANY>} the imported module
  */

--- a/test/stylelint/threads.test.js
+++ b/test/stylelint/threads.test.js
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import { join } from "node:path";
-import { beforeEach, describe, it } from "node:test";
+import { describe, it } from "node:test";
 
 // @ts-expect-error no types
 import normalizePath from "normalize-path";
 
+import { lintFiles, setup } from "../../src/checks/stylelint-worker.js";
 import { getLoadedStylelint } from "../../src/checks/stylelint.js";
 
 import pack from "./utils/pack.js";
@@ -53,14 +54,6 @@ describe("Threading", () => {
   });
 
   describe("worker coverage", () => {
-    beforeEach(() => {
-      // The worker holds its stylelint path in module state, so drop the copy
-      // a previous test set up.
-      delete require.cache[
-        require.resolve("../../src/checks/stylelint-worker.cjs")
-      ];
-    });
-
     it("worker can start", async () => {
       const mockStylelintPath = join(
         import.meta.dirname,
@@ -72,11 +65,8 @@ describe("Threading", () => {
 
       mock._reset();
 
-      const {
-        lintFiles,
-        setup,
-      } = require("../../src/checks/stylelint-worker.cjs");
-
+      // `setup` resets the path and the cached stylelint, so the module state
+      // another test left behind does not carry into this one.
       setup({ stylelintPath: mockStylelintPath });
 
       await lintFiles("foo");

--- a/types/checks/eslint.d.ts
+++ b/types/checks/eslint.d.ts
@@ -2,7 +2,7 @@ declare namespace _default {
   export let name: string;
   export let label: string;
   export let filesSource: string;
-  export { schema };
+  export const schema: any;
   export namespace defaults {
     let cache: boolean;
     let cacheLocation: string;
@@ -14,6 +14,7 @@ declare namespace _default {
   export { getESLintOptions };
 }
 export default _default;
+export type EXPECTED_ANY = any;
 export type ESLint = import("eslint").ESLint;
 export type Formatter = import("eslint").ESLint.Formatter;
 export type LintResult = import("eslint").ESLint.LintResult;
@@ -32,7 +33,6 @@ export type ESLintClass = {
  * @returns {ESLintOptions} the options ESLint itself understands
  */
 export function getESLintOptions(options: Options): ESLintOptions;
-declare const schema: any;
 /**
  * @param {CheckContext} context check context
  * @returns {Promise<CheckInstance>} eslint check

--- a/types/checks/stylelint-worker.d.ts
+++ b/types/checks/stylelint-worker.d.ts
@@ -1,4 +1,3 @@
-export type EXPECTED_ANY = any;
 export type LintResult = import("./stylelint.js").LintResult;
 export type StylelintOptions = import("./stylelint.js").StylelintOptions;
 export type Stylelint = import("./stylelint.js").Stylelint;

--- a/types/checks/stylelint.d.ts
+++ b/types/checks/stylelint.d.ts
@@ -2,7 +2,7 @@ declare namespace _default {
   export let name: string;
   export let label: string;
   export let filesSource: string;
-  export { schema };
+  export const schema: any;
   export namespace defaults {
     let cache: boolean;
     let cacheLocation: string;
@@ -14,6 +14,7 @@ declare namespace _default {
   export { create };
 }
 export default _default;
+export type EXPECTED_ANY = any;
 export type Formatter = import("stylelint").Formatter;
 export type FormatterType = import("stylelint").FormatterType;
 export type LintResult = import("stylelint").LintResult;
@@ -62,7 +63,6 @@ export function getLoadedStylelint(
 export function getStylelintOptions(
   options: Options,
 ): Partial<StylelintOptions>;
-declare const schema: any;
 /**
  * @param {CheckContext} context check context
  * @returns {Promise<CheckInstance>} stylelint check

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -128,12 +128,6 @@ export type NormalizedOptions = {
  * @returns {NormalizedOptions} normalized plugin options
  */
 export function getOptions(pluginOptions: Options): NormalizedOptions;
-export namespace schema {
-  let type: string;
-  let additionalProperties: boolean;
-  let properties: any;
-  let required: string[];
-}
 /**
  * Runs from `compiler.hooks.validate`, so webpack's own `validate: false`
  * turns it off the way it does for webpack's plugins.

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -30,8 +30,8 @@ export type EXPECTED_ANY = any;
 export function arrify<T>(value: T): ArrifyResult<T>;
 /**
  * A package name is imported as it is, so a test can still mock it. A path may
- * name a directory or a CommonJS entry, neither of which ESM resolves, so
- * CommonJS resolution finds the file first.
+ * name a directory, which `import.meta.resolve` returns unchanged for
+ * `import` to reject, so CommonJS resolution finds the entry file first.
  * @param {string} specifier a module specifier or path
  * @returns {Promise<EXPECTED_ANY>} the imported module
  */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

`createRequire` was reaching into five places in `src/`. After this it is in four, and every one of them reads a schema.

- **The stylelint worker is ECMAScript.** It was `.cjs` only because jest could not `require` an ES module in band, and jest is gone. I drove jest-worker against an ESM worker to confirm before converting — `setup` and the method both work over worker threads. It also drops its private copy of `importFrom` and shares the one in `utils.js`.
- **The stylelint adapter imports it** rather than requiring it, and hands jest-worker the path from `import.meta.resolve`.
- **The ESLint adapter loads ESLint's suppressions service with `import()`**, resolving the package through `eslint/package.json` instead of `require.resolve`.

**Schemas stay on `createRequire`** — an import attribute still trips `eslint-plugin-import` — but they are read on demand now. A build that validates nothing never touches them, and `compiler.validate` takes the getter, which is why #313 had to land first:

```js
check(() => getSchemas().schema, pluginOptions, { … });
```

Adapters expose `schema` as a getter, so `adapter.schema.properties` still reads the same for anything outside this package.

**One `createRequire` is left, in `importFrom`, and it cannot go.** `eslintPath` and `stylelintPath` may name a directory — the README documents it — and ESM will not resolve one:

```
test/mock/eslint
  require.resolve      -> …/test/mock/eslint/index.js
  import.meta.resolve  -> file:///…/test/mock/eslint
  import() of that     -> FAIL ERR_UNSUPPORTED_DIR_IMPORT
```

The alternative is reimplementing CommonJS resolution by hand, which is worse than calling it. The comment there now names `import.meta.resolve` so this is not re-attempted.

**What kind of change does this PR introduce?**

refactor.

**Did you add tests for your changes?**

No new cases — the existing suite is the check, and the worker rename is exactly what it covers. 135 passing on ESLint 10, 137 on ESLint 9. `test/stylelint/threads.test.js` imports the worker instead of requiring it, and no longer evicts it from `require.cache`: `setup` resets the cached stylelint itself, which is what the eviction was standing in for.

Beyond the suite I checked the two things a module-system change can break silently: the threaded worker running from **both** dist builds (each reports the fixture's one stylelint error, so it really linted), and the ESLint 9 suppressions path, whose service now arrives through `import()`.

**Does this PR introduce a breaking change?**

No. `dist/cjs` still emits the worker as CommonJS — babel rewrites `import.meta.resolve` to `require.resolve` there, which I verified against the compiler before relying on it.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a, and no changeset: nothing here changes what a user configures or sees.

**Use of AI**

Written with Claude Code, driven interactively. I asked for CommonJS to be gone except the lazy schema read; Claude tested jest-worker with an ESM worker and babel with `import.meta.resolve` before changing either, and established with evidence that `importFrom` is the one case that cannot move. I reviewed the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy)_