### PR TITLE
docs: show how to run the checks in one mode only

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,38 @@ Set it to `false` to start a watch run quiet: nothing is linted until you touch
 a file, and only the modules webpack rebuilds are reported. A build is nothing
 but a first compilation, so it lints either way — the option cannot silence one.
 
+#### Running the checks in one mode only
+
+There is no option for this and none is needed: `plugins` ignores a falsy entry,
+so `&&` decides whether the plugin is there at all. A configuration function is
+handed the `--env` values, and `webpack-cli` states the mode in them:
+
+| Value                             | Set by                                |
+| --------------------------------- | ------------------------------------- |
+| `WEBPACK_SERVE`                   | `webpack serve`                       |
+| `WEBPACK_WATCH`                   | `webpack watch` and `webpack --watch` |
+| `WEBPACK_BUILD`, `WEBPACK_BUNDLE` | `webpack`, a build that runs once     |
+
+```js
+import DiagnosticsPlugin from "diagnostics-webpack-plugin";
+import { defineConfig } from "webpack";
+
+export default defineConfig((env) => ({
+  plugins: [
+    // Both values are read because each command sets only its own: `serve` sets
+    // `WEBPACK_SERVE` and `--watch` sets `WEBPACK_WATCH`, so asking for one of
+    // them misses the other way of watching. Read `WEBPACK_BUILD` instead to
+    // check a build that runs once and leave a watch run alone.
+    (env.WEBPACK_SERVE || env.WEBPACK_WATCH) &&
+      new DiagnosticsPlugin({ checks: ["eslint", "stylelint"] }),
+  ],
+}));
+```
+
+This is worth doing when something else already lints the same files — a CI job
+running `eslint .`, or an editor — and the release build need not pay for it
+twice.
+
 ### Shared options
 
 These can be set at the top level, where they apply to every check, or inside one check, where they apply to that check alone.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Replaces #321, which added a `runOn` option for this. webpack's own configuration already answers it: `plugins` accepts a falsy entry, and a configuration function is handed the `--env` values that `webpack-cli` states the mode in — so `&&` decides whether the plugin exists at all, which is strictly more complete than an option gating what it taps. The README now shows it with `defineConfig`, lists which value each command sets, and says why watching needs both of them read.

Verified rather than assumed: `plugins` items accept `Falsy` (`false | 0 | '' | null | undefined`) per `schemas/WebpackOptions.json`, `webpack.defineConfig` takes a `(env, argv)` factory, and in `webpack-cli@7.2.3` `webpack serve` sets `WEBPACK_SERVE` alone while `webpack --watch` sets `WEBPACK_WATCH` alone, so neither implies the other.

**What kind of change does this PR introduce?**

docs

**Did you add tests for your changes?**

No — documentation only, no behaviour change.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Documented here in `README.md`; the webpack.js.org page wants the same section after release.

**Use of AI**

AI was used. Claude Code had proposed the `runOn` option in #321, was told a conditional plugin entry is the better answer, verified the three facts above against the webpack schema, `lib/config/defineConfig.js` and the published `webpack-cli` source, then wrote this section and ran lint and the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy)_