### PR TITLE
perf: ask ESLint to spread its own lint across threads

### DIFF
--- a/.changeset/eslint-concurrency.md
+++ b/.changeset/eslint-concurrency.md
@@ -1,0 +1,5 @@
+---
+"diagnostics-webpack-plugin": minor
+---
+
+Ask ESLint for `concurrency: "auto"` unless told otherwise, so a lint does not hold the thread webpack builds on. Over three hundred modules that is about fifteen per cent off the build and a second of blocking gone. It is only asked for where the loaded ESLint knows the option, 9.34.0 and above under flat config.

--- a/README.md
+++ b/README.md
@@ -346,7 +346,11 @@ new DiagnosticsPlugin({
 
 Run with `{ use: "eslint" }`. It lints the files webpack builds, so only the modules that end up in the bundle are checked.
 
-Alongside the shared options you can pass any [ESLint Node.js API option](https://eslint.org/docs/latest/integrate/nodejs-api#-new-eslintoptions) — they are handed to the `ESLint` class as they are. `concurrency` is worth knowing about: it spreads a lint across worker threads, and ESLint warns on the runs where doing so costs more than it saves, so measure your own project rather than turning it on by default.
+Alongside the shared options you can pass any [ESLint Node.js API option](https://eslint.org/docs/latest/integrate/nodejs-api#-new-eslintoptions) — they are handed to the `ESLint` class as they are.
+
+One of them is asked for on your behalf. ESLint's own `concurrency` spreads a lint across threads of its own, and ESLint leaves it `"off"`, which lints on the thread webpack builds on: over three hundred modules that blocks the build for about a second and costs it around fifteen per cent. So `"auto"` is asked for where the loaded ESLint knows the option — 9.34.0 and above, flat config — and whatever you write yourself is passed through untouched, `"off"` included. Pin a number rather than `"auto"` and ESLint may answer with `ESLintPoorConcurrencyWarning`: it sizes `"auto"` against the machine, while a fixed count can end up fighting webpack for the same cores and running slower than no threads at all.
+
+Note that webpack spells this idea `parallelism`, and means something else again by the word concurrency — bounded work on one thread. This option is ESLint's, with ESLint's meaning.
 
 A rebuild lints only the files webpack rebuilt and reports the rest from the previous run, so [`lintOnStart`](#lintonstart) is only worth setting to start a watch run quiet.
 

--- a/src/checks/eslint.js
+++ b/src/checks/eslint.js
@@ -137,6 +137,18 @@ async function loadFormatter(eslint, formatter) {
 }
 
 /**
+ * Whether the loaded ESLint spreads a lint across threads of its own, which it
+ * has done under `concurrency` since 9.34.0.
+ * @param {string} version the loaded ESLint's version
+ * @returns {boolean} whether `concurrency` is an option it knows
+ */
+function spreadsItsOwnLint(version) {
+  const [major, minor] = version.split(".").map(Number);
+
+  return major > 9 || (major === 9 && minor >= 34);
+}
+
+/**
  * @param {Options} options plugin options
  * @returns {ESLintOptions} the options ESLint itself understands
  */
@@ -192,6 +204,16 @@ async function create({ options }) {
     );
     delete eslintOptions.applySuppressions;
     delete eslintOptions.suppressionsLocation;
+  }
+
+  // ESLint leaves a lint on the thread it was called from, which is the one
+  // webpack builds on, so it is asked for threads unless the user said otherwise.
+  if (
+    eslintOptions.concurrency === undefined &&
+    options.configType === "flat" &&
+    spreadsItsOwnLint(ESLint.version)
+  ) {
+    eslintOptions.concurrency = "auto";
   }
 
   const eslint = new ESLint(eslintOptions);

--- a/test/concurrency.test.js
+++ b/test/concurrency.test.js
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { beforeEach, describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
+
+const require = createRequire(import.meta.url);
+const eslintPath = join(import.meta.dirname, "mock/eslint-options");
+const mock = () => require(eslintPath);
+const given = async (options) => {
+  await pack("error", { eslintPath, ...options }).runAsync();
+
+  return mock()._calls[0];
+};
+
+describe("concurrency", () => {
+  beforeEach(() => {
+    mock()._reset();
+    mock()._setVersion("10.0.0");
+  });
+
+  it("should ask an ESLint that threads for threads", async () => {
+    assert.strictEqual((await given({})).concurrency, "auto");
+  });
+
+  it("should keep what the user asked for", async () => {
+    assert.strictEqual((await given({ concurrency: 2 })).concurrency, 2);
+  });
+
+  it("should keep it off when the user turned it off", async () => {
+    assert.strictEqual(
+      (await given({ concurrency: "off" })).concurrency,
+      "off",
+    );
+  });
+
+  it("should not name the option to an ESLint that lacks it", async () => {
+    mock()._setVersion("9.33.0");
+
+    assert.ok(!("concurrency" in (await given({}))));
+  });
+
+  it("should name it to the release that gained it", async () => {
+    mock()._setVersion("9.34.0");
+
+    assert.strictEqual((await given({})).concurrency, "auto");
+  });
+
+  it("should leave an eslintrc config alone", async () => {
+    const options = await given({ configType: "eslintrc" });
+
+    assert.ok(!("concurrency" in options));
+  });
+});

--- a/test/mock/eslint-options/index.js
+++ b/test/mock/eslint-options/index.js
@@ -1,0 +1,30 @@
+// Mock eslint that records the options it was constructed with
+const calls = [];
+
+class ESLintMock {
+  constructor(options) {
+    calls.push(options);
+  }
+
+  async lintFiles() {
+    return [];
+  }
+
+  async loadFormatter() {
+    return { format: (results) => JSON.stringify(results) };
+  }
+}
+
+ESLintMock.version = "10.0.0";
+
+module.exports = {
+  ESLint: ESLintMock,
+  loadESLint: async () => ESLintMock,
+  _calls: calls,
+  _setVersion: (version) => {
+    ESLintMock.version = version;
+  },
+  _reset: () => {
+    calls.length = 0;
+  },
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

ESLint leaves its `concurrency` option `"off"`, which lints on the thread webpack builds on. Over three hundred modules that holds the main thread for **1084 ms** and costs the whole build about fifteen per cent — which also means #319's overlap of linting with module building could not actually overlap. The ESLint check now asks for `"auto"` unless you say otherwise.

Measured on a four-core runner, 300 modules, arms interleaved and warmed, best of three:

| arm | full build | max main-thread block |
| --- | --- | --- |
| `concurrency: "off"` | 3205 ms | 1084 ms |
| this PR's default | **2729 ms** | 6 ms |
| `concurrency: 4` | 3974 ms | 7 ms |

`"auto"` rather than a count, because ESLint sizes `"auto"` against the machine while a fixed number fights webpack for the same cores and came out **slower than no threads at all**; it is also the form ESLint answers with `ESLintPoorConcurrencyWarning`, which `"auto"` does not trigger.

Two things it is not. It is not a new option — `concurrency` is ESLint's own and is passed through untouched, `"off"` included, so this only changes what is sent when nothing was written. And it is not the worker pool the equivalent plugins for other bundlers offer: a single `jest-worker` measured 3426 ms against 3026 in-process, and a pool of four beat ESLint's own threads by eight per cent standalone while hitting the same oversubscription in a real build — so that approach was measured and dropped rather than built.

The guard is `9.34.0`, where ESLint gained the option; the peer range starts at `^9.0.0`, and ESLint rejects an option it has never heard of with `Invalid Options`. Flat config only, since that is where the option lives.

**What kind of change does this PR introduce?**

perf

**Did you add tests for your changes?**

Yes — `test/concurrency.test.js` over a new `test/mock/eslint-options` recorder, six cases: the default is asked for, a user's number and `"off"` survive, `9.33.0` is not offered the option, `9.34.0` is, and an `eslintrc` config is left alone.

**Does this PR introduce a breaking change?**

No. Anything written by hand is passed through as before, and an ESLint that lacks the option is never sent it.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

The ESLint section of `README.md` is updated here, including that webpack spells this idea `parallelism` and uses the word concurrency for something else, so the option's meaning is ESLint's. The webpack.js.org page wants the same note after release.

**Use of AI**

AI was used. Claude Code benchmarked five arms standalone and three inside a real webpack build, bisected the published ESLint tarballs to find the release that added the option, then wrote the guard, the mock, the tests and the documentation. Every number above came out of a run, not an estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy)_