### PR TITLE
feat: add an oxlint check

### DIFF
--- a/.changeset/oxlint-check.md
+++ b/.changeset/oxlint-check.md
@@ -1,0 +1,5 @@
+---
+"diagnostics-webpack-plugin": minor
+---
+
+Add an `oxlint` check, which lints the files webpack builds with [oxlint](https://oxc.rs/docs/guide/usage/linter.html) and reports what it finds at oxlint's own severities. Run it with `{ use: "oxlint" }`; `oxlint >= 1` is an optional peer.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 This plugin runs linters, type checkers and other diagnostic tools over your sources during the webpack build and reports what they find as webpack errors and warnings.
 
-It replaces `eslint-webpack-plugin` and `stylelint-webpack-plugin`: one plugin, one place to configure how problems are reported, and one pass over your project. Today it runs [`ESLint`](https://eslint.org/), [`Stylelint`](https://stylelint.io/) and [`TypeScript`](https://www.typescriptlang.org/); more linters and diagnostic tools are meant to be added the same way.
+It replaces `eslint-webpack-plugin` and `stylelint-webpack-plugin`: one plugin, one place to configure how problems are reported, and one pass over your project. Today it runs [`ESLint`](https://eslint.org/), [`Stylelint`](https://stylelint.io/), [`oxlint`](https://oxc.rs/docs/guide/usage/linter.html) and [`TypeScript`](https://www.typescriptlang.org/); more linters and diagnostic tools are meant to be added the same way.
 
 ## Getting Started
 
@@ -41,10 +41,10 @@ pnpm add -D diagnostics-webpack-plugin
 
 > [!NOTE]
 >
-> Install the tools you want to run as well — the plugin only requires the ones you enable. It supports `eslint >= 9`, `stylelint >= 17` and `typescript >= 5`:
+> Install the tools you want to run as well — the plugin only requires the ones you enable. It supports `eslint >= 9`, `stylelint >= 17`, `oxlint >= 1` and `typescript >= 5`:
 
 ```console
-npm install eslint stylelint typescript --save-dev
+npm install eslint stylelint oxlint typescript --save-dev
 ```
 
 Then add the plugin to your webpack configuration and enable a check for each language you want inspected:
@@ -458,6 +458,62 @@ type stylelintPath = string;
 - Default: `stylelint`
 
 Path to the `stylelint` instance that will be used for linting.
+
+## oxlint
+
+Run with `{ use: "oxlint" }`, and requires `oxlint >= 1`. It lints the files
+webpack builds, as the ESLint check does, and reads whatever `.oxlintrc.json`
+oxlint finds for itself.
+
+```js
+new DiagnosticsPlugin({ checks: ["eslint", "oxlint"] });
+```
+
+oxlint is a binary behind a Node entry rather than a library, so this check runs
+it and reads the JSON it answers with. Two things follow. Its severities are
+oxlint's own — a rule set to `"error"` in `.oxlintrc.json` is reported as a
+webpack error and one set to `"warn"` as a warning, and [`reportAs`](#reportas)
+moves them from there as it does for every check. And the options this check does
+not name are not guessed at: write them as [`args`](#args), the flags oxlint
+itself documents.
+
+### `oxlintPath`
+
+- Type:
+
+```ts
+type oxlintPath = string;
+```
+
+- Default: `oxlint`
+
+Path to the `oxlint` instance that will be used for linting.
+
+### `configFile`
+
+- Type:
+
+```ts
+type configFile = string;
+```
+
+- Default: unset, leaving oxlint to find its own
+
+Path to the `.oxlintrc.json` to lint with.
+
+### `args`
+
+- Type:
+
+```ts
+type args = string[];
+```
+
+- Default: `[]`
+
+Arguments passed to oxlint as they are, for the flags this check does not name —
+`["--deny", "correctness"]`, say. Not `--format`: the check asks for JSON and
+formats the results itself, and oxlint declines being asked twice.
 
 ## TypeScript
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,8 @@ import configs from "eslint-config-webpack/configs.js";
 export default defineConfig([
   {
     ignores: [
+      "test/oxlint/fixtures/**/*",
+      "test/oxlint/outputs/**/*",
       "test/stylelint/fixtures/**/*",
       "test/stylelint/outputs/**/*",
       "test/typescript/fixtures/**/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^17.5.0",
         "npm-run-all": "^4.1.5",
+        "oxlint": "^1.82.0",
         "postcss-scss": "^4.0.9",
         "prettier": "^3.9.6",
         "stylelint": "^17.15.0",
@@ -5084,6 +5085,329 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.82.0.tgz",
+      "integrity": "sha512-a3LB+C5Dsj5b/qtmG/mv5WrzuiXEpg1KF5nXWcEvaoN5TYAqkIvxPOwTPp3Jy/FoGpRo8zsTFhMElMXfeoOEzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.82.0.tgz",
+      "integrity": "sha512-OBlhRgNqFblGpGenno/aqOfJLOkQ2B8Ig3iDAalfn0H8hJGZKXPeexCRTDm6uwv6YUjSA9Xnwt1y/Bgj5ZH8uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.82.0.tgz",
+      "integrity": "sha512-dsopxqtY5ZdyT9uLHyGt1SyiLop6hi7hWI3PKpePodkRQOkLaCm+OE4fR9CAz9qdfjiFO8531tX/QDyP/psjFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.82.0.tgz",
+      "integrity": "sha512-94Lu0SgTClKColU66g1VDuigV3HkcbkJBnTtZjGYfE8UPugaWDgKrm2icjC6HJVUYler2OXaHP/X0TBy8+CowQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.82.0.tgz",
+      "integrity": "sha512-hne/V06ewhh1i0w8+l7GDNROAGCGPmyFuOwiP7YTRu0JycyStJ4785dmF8xU5p0uUwt2emvIF9vc7Xjis+cJ0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.82.0.tgz",
+      "integrity": "sha512-aWY2xtbZf1LneW9Qsv/n2Sp8gOu74JrlQzEtj4coHX2SHFrCfhmAumaU+sI/A5nr+yoTRTSmI/pL2s6ADlNSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.82.0.tgz",
+      "integrity": "sha512-Fe+TtXCXMh/5f7kWlZ2VAwsMumZWtraFlKVk1NJlL52/beGwfDE7ov+/8gVirHzWokzGu7X65hSPq0ucPDskWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.82.0.tgz",
+      "integrity": "sha512-6azCZ6OJudlvipNttXCCQcyeFfcJ/NvUZdSN1z8elo73kCHtyQC7WTiUcSjWYvJ1jaq9KDUyMAoAS/vNzhBomA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.82.0.tgz",
+      "integrity": "sha512-PLEaSD8IAIIlwW4dwOd9YaxuxeOpwiXL4J24rcnE4iNtyM5j9Q9/3+gti08oXpx0u2ygNjRDx9xjWWpQonuJEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.82.0.tgz",
+      "integrity": "sha512-D94em/BwknNTn4vqxjHh5wb2oL566eFhArabqKIr0cNZMHOJuiraFp1A8tXpH05bbE5tqwEfLXTI0MWEGtn3Dw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.82.0.tgz",
+      "integrity": "sha512-MOprxBaoYU2D4VgxXCl3ghydThWtx7Um1lL51kGYNeQ5Al7WzsH7/tqGdNtbLrIWnjq3bsm13+nz/gRIxjrOXw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.82.0.tgz",
+      "integrity": "sha512-5h55QsfJ/luDXZzC20k6SNOY1Az+dCP9WvntKtcUWh2JhckAdwApY2ZusaBTwLENnReXU+A2fJtSrYvZJNKNPg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.82.0.tgz",
+      "integrity": "sha512-IE8NJNLlHr0CaXyGJPGVn0eTkUyoj1I2UfA8x7I4PSOYKsQ/6btVC7Pywrj5onk0cMH25r6Z38SoN3AvE5Zuog==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.82.0.tgz",
+      "integrity": "sha512-XUUUxaBo9XKl+J1B9EmP1cTGQPddzeURvoGkfwh/94PGnbW+hBprDljneoI2M1jzC1bzrIV3ihc7iM9UXl8+tg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.82.0.tgz",
+      "integrity": "sha512-SWLSFulX9TDuH6yvbPYp4+VNn6jkkIvvI+KiujDM5rWBRHEfkesCC/pCneIIUr6ovkxZ5fRtpi2v5Cz5FrMJZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.82.0.tgz",
+      "integrity": "sha512-BQy35f6ZUdNr9a6c7B7orxQTcLjByGT2z3WAgmRovpRwmPYAaJ+NTplmMzhdjdJ4qSchfMNZy/Ukg+qRg6zseQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.82.0.tgz",
+      "integrity": "sha512-V4QhSTg5gctZue8RJjsGi7NpQPThr/p1/HfmiMC5kfe1KFEup9SQRVub4A6kijQjdHfxj7bLL1KO3QO7/5bwMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.82.0.tgz",
+      "integrity": "sha512-TUSCLaKB2yktpFAJ/r3HAUYsaV/3DT7JS4iNKyoh3a9YNwD0UG7Ezh4D8m23654vQcU6P/RQrCAjRPKe4peP/A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.82.0.tgz",
+      "integrity": "sha512-VTVoRIWJTb+wvUX8EYoPArfFH02whuR10goFXE/LHRRX33ajRrFgqbcONXZMiF4C5rnattfkm87HqYn8jb8hmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -15588,6 +15912,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.82.0.tgz",
+      "integrity": "sha512-+iFM1BGw1ntYJt3QngbJmjbrGxPaKMUADOXOijpWGnYcBPq8YZnQftSS1C+pVcDYy9YxqDVJKQqQkTazTQMboQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.82.0",
+        "@oxlint/binding-android-arm64": "1.82.0",
+        "@oxlint/binding-darwin-arm64": "1.82.0",
+        "@oxlint/binding-darwin-x64": "1.82.0",
+        "@oxlint/binding-freebsd-x64": "1.82.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.82.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.82.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.82.0",
+        "@oxlint/binding-linux-arm64-musl": "1.82.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.82.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.82.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.82.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.82.0",
+        "@oxlint/binding-linux-x64-gnu": "1.82.0",
+        "@oxlint/binding-linux-x64-musl": "1.82.0",
+        "@oxlint/binding-openharmony-arm64": "1.82.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.82.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.82.0",
+        "@oxlint/binding-win32-x64-msvc": "1.82.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=7.0.2001",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "linter",
     "eslint",
     "stylelint",
+    "oxlint",
     "typescript",
     "plugin",
     "webpack"
@@ -95,6 +96,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.5.0",
     "npm-run-all": "^4.1.5",
+    "oxlint": "^1.82.0",
     "postcss-scss": "^4.0.9",
     "prettier": "^3.9.6",
     "stylelint": "^17.15.0",
@@ -103,12 +105,16 @@
   },
   "peerDependencies": {
     "eslint": "^9.0.0 || ^10.0.0",
+    "oxlint": "^1.0.0",
     "stylelint": "^17.0.0",
     "typescript": "^5.0.0 || ^6.0.0",
     "webpack": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "eslint": {
+      "optional": true
+    },
+    "oxlint": {
       "optional": true
     },
     "stylelint": {

--- a/src/checks/index.js
+++ b/src/checks/index.js
@@ -2,6 +2,7 @@
 /** @typedef {any} EXPECTED_ANY */
 
 import eslint from "./eslint.js";
+import oxlint from "./oxlint.js";
 import stylelint from "./stylelint.js";
 import typescript from "./typescript.js";
 
@@ -65,6 +66,7 @@ import typescript from "./typescript.js";
 /** @type {Map<string, CheckAdapter>} */
 const adapters = new Map([
   [eslint.name, /** @type {CheckAdapter} */ (eslint)],
+  [oxlint.name, /** @type {CheckAdapter} */ (oxlint)],
   [stylelint.name, /** @type {CheckAdapter} */ (stylelint)],
   [typescript.name, /** @type {CheckAdapter} */ (typescript)],
 ]);

--- a/src/checks/oxlint.js
+++ b/src/checks/oxlint.js
@@ -1,0 +1,224 @@
+// eslint-disable-next-line jsdoc/reject-any-type
+/** @typedef {any} EXPECTED_ANY */
+
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+
+import { toPosixPath } from "../utils.js";
+
+/** @typedef {import("./index.js").CheckContext} CheckContext */
+/** @typedef {import("./index.js").CheckInstance} CheckInstance */
+/** @typedef {import("../options.js").CheckOptions} Options */
+
+/**
+ * @typedef {object} FileResult
+ * @property {string} filename the file every diagnostic of it was found in
+ * @property {Diagnostic[]} diagnostics what oxlint found there
+ */
+
+/**
+ * @typedef {object} Diagnostic
+ * @property {string} message what oxlint found
+ * @property {string=} code the rule it came from
+ * @property {string} severity how oxlint rates it
+ * @property {string} filename the file it was found in
+ * @property {string=} help what oxlint suggests
+ * @property {{ label?: string, span: { line: number, column: number } }[]=} labels where it is
+ */
+
+const nodeRequire = createRequire(import.meta.url);
+
+// An argument list is not unbounded, so a batch past this is run in several.
+const FILES_PER_RUN = 500;
+
+/** @type {{ plugin: EXPECTED_ANY, shared: EXPECTED_ANY, own: EXPECTED_ANY } | undefined} */
+let schemas;
+
+/**
+ * Read on demand so that requiring the plugin does not read three files.
+ * @returns {{ plugin: EXPECTED_ANY, shared: EXPECTED_ANY, own: EXPECTED_ANY }} the schemas
+ */
+function getSchemas() {
+  if (!schemas) {
+    schemas = {
+      plugin: nodeRequire("../options.json"),
+      shared: nodeRequire("../shared-options.json"),
+      own: nodeRequire("./oxlint.json"),
+    };
+  }
+
+  return schemas;
+}
+
+/**
+ * oxlint is a binary behind a Node entry rather than a library, so it is run
+ * rather than called.
+ * @param {Options} options options
+ * @returns {string} the script that runs it
+ */
+function findOxlint(options) {
+  const specifier = options.oxlintPath || "oxlint";
+  const manifest = nodeRequire.resolve(join(specifier, "package.json"));
+  const { bin } = nodeRequire(manifest);
+
+  return resolve(dirname(manifest), typeof bin === "string" ? bin : bin.oxlint);
+}
+
+/**
+ * @param {string} script the oxlint entry to run
+ * @param {string[]} args what to run it with
+ * @param {string} cwd where to run it
+ * @returns {Promise<Diagnostic[]>} what it found
+ */
+function run(script, args, cwd) {
+  return new Promise((promiseResolve, reject) => {
+    execFile(
+      process.execPath,
+      [script, ...args],
+      // A project's worth of diagnostics does not fit the default buffer.
+      { cwd, maxBuffer: 64 * 1024 * 1024 },
+      (error, stdout) => {
+        // oxlint answers non-zero when it found something, which is not a
+        // failure to run; an empty answer with an error is.
+        if (!stdout && error) {
+          reject(error);
+          return;
+        }
+
+        try {
+          promiseResolve(JSON.parse(stdout).diagnostics || []);
+        } /* istanbul ignore next -- oxlint declines a second `--format` rather
+             than answering in one this cannot read, so nothing reaches here
+             short of oxlint changing what `--format=json` prints */ catch {
+          reject(
+            new Error(
+              `oxlint answered something other than the JSON it was asked for: ${stdout.slice(0, 200)}`,
+            ),
+          );
+        }
+      },
+    );
+  });
+}
+
+/**
+ * @param {string} filename the file it was found in
+ * @param {Diagnostic} diagnostic what oxlint found
+ * @returns {string} it as one line, where oxlint's own formatters are a second run
+ */
+function formatDiagnostic(filename, diagnostic) {
+  const [label] = diagnostic.labels || [];
+  const at = label ? `:${label.span.line}:${label.span.column}` : "";
+  const rule = diagnostic.code ? `  ${diagnostic.code}` : "";
+
+  return `${filename}${at}  ${diagnostic.severity}  ${diagnostic.message}${rule}`;
+}
+
+/**
+ * @param {CheckContext} context check context
+ * @returns {Promise<CheckInstance>} oxlint check
+ */
+async function create({ options }) {
+  const script = findOxlint(options);
+  const cwd = String(options.context);
+  const flags = [
+    "--format=json",
+    ...(options.configFile ? ["--config", String(options.configFile)] : []),
+    ...(options.fix ? ["--fix"] : []),
+    .../** @type {string[]} */ (options.args || []),
+  ];
+
+  return {
+    async lintFiles(files) {
+      /** @type {Diagnostic[]} */
+      const found = [];
+
+      for (let i = 0; i < files.length; i += FILES_PER_RUN) {
+        found.push(
+          ...(await run(
+            script,
+            [...flags, ...files.slice(i, i + FILES_PER_RUN)],
+            cwd,
+          )),
+        );
+      }
+
+      return found;
+    },
+    async getResults(results) {
+      // One result per file rather than per diagnostic: the plugin remembers a
+      // file by one result, so several would leave only the last of them. The
+      // path is made absolute at the same time, being named relative to where
+      // oxlint ran and remembered as webpack spells it.
+      /** @type {Map<string, FileResult>} */
+      const byFile = new Map();
+
+      for (const diagnostic of /** @type {Diagnostic[]} */ (results)) {
+        const filename = toPosixPath(resolve(cwd, diagnostic.filename));
+        const found = byFile.get(filename);
+
+        if (found) found.diagnostics.push(diagnostic);
+        else byFile.set(filename, { filename, diagnostics: [diagnostic] });
+      }
+
+      return [...byFile.values()];
+    },
+    splitResults(results) {
+      /** @type {FileResult[]} */
+      const errors = [];
+      /** @type {FileResult[]} */
+      const warnings = [];
+
+      // A file holding both is reported in both, each with its own half.
+      for (const file of /** @type {FileResult[]} */ (results)) {
+        for (const [severity, into] of [
+          ["error", errors],
+          ["warning", warnings],
+        ]) {
+          const diagnostics = file.diagnostics.filter(
+            (diagnostic) =>
+              (diagnostic.severity === "error") === (severity === "error"),
+          );
+
+          if (diagnostics.length > 0) {
+            /** @type {FileResult[]} */ (into).push({ ...file, diagnostics });
+          }
+        }
+      }
+
+      return { errors, warnings };
+    },
+    async getFormatter(formatter) {
+      if (typeof formatter === "function") {
+        return async (results) => String(await formatter(results));
+      }
+
+      return async (results) =>
+        /** @type {FileResult[]} */ (results)
+          .flatMap((file) =>
+            file.diagnostics.map((diagnostic) =>
+              formatDiagnostic(file.filename, diagnostic),
+            ),
+          )
+          .join("\n");
+    },
+    async cleanup() {},
+  };
+}
+
+export default {
+  name: "oxlint",
+  label: "oxlint",
+  filesSource: "modules",
+  get schema() {
+    return getSchemas().own;
+  },
+  defaults: {
+    extensions: ["js", "mjs", "cjs", "jsx", "ts", "mts", "cts", "tsx"],
+  },
+  defaultExclude: () => "**/node_modules/**",
+  create,
+  resultPath: (/** @type {EXPECTED_ANY} */ result) =>
+    /** @type {FileResult} */ (result).filename,
+};

--- a/src/checks/oxlint.json
+++ b/src/checks/oxlint.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "oxlintPath": {
+      "description": "Path to the `oxlint` instance that will be used for linting.",
+      "type": "string"
+    },
+    "configFile": {
+      "description": "Path to the `.oxlintrc.json` to lint with. oxlint finds its own when unset.",
+      "type": "string"
+    },
+    "args": {
+      "description": "Arguments passed to oxlint as they are, for the flags this check does not name.",
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/test/oxlint/fixtures/bad/.oxlintrc.json
+++ b/test/oxlint/fixtures/bad/.oxlintrc.json
@@ -1,0 +1,1 @@
+{ "rules": { "no-debugger": "error", "no-unused-vars": "warn" } }

--- a/test/oxlint/fixtures/bad/index.js
+++ b/test/oxlint/fixtures/bad/index.js
@@ -1,0 +1,2 @@
+require("./rules");
+require("./twice");

--- a/test/oxlint/fixtures/bad/rules.js
+++ b/test/oxlint/fixtures/bad/rules.js
@@ -1,0 +1,5 @@
+const unused = 1;
+
+debugger;
+
+module.exports = 2;

--- a/test/oxlint/fixtures/bad/twice.js
+++ b/test/oxlint/fixtures/bad/twice.js
@@ -1,0 +1,5 @@
+const first = 1;
+
+const second = 2;
+
+module.exports = 3;

--- a/test/oxlint/fixtures/good/.oxlintrc.json
+++ b/test/oxlint/fixtures/good/.oxlintrc.json
@@ -1,0 +1,1 @@
+{ "rules": { "no-debugger": "error", "no-unused-vars": "warn" } }

--- a/test/oxlint/fixtures/good/index.js
+++ b/test/oxlint/fixtures/good/index.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/oxlint/fixtures/package.json
+++ b/test/oxlint/fixtures/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/test/oxlint/outputs/main.js
+++ b/test/oxlint/outputs/main.js
@@ -1,0 +1,102 @@
+/*
+ * ATTENTION: The "eval" devtool has been used (maybe by default in mode: "development").
+ * This devtool is neither made for production nor for readable output files.
+ * It uses "eval()" calls to create a separate source file in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with "devtool: false".
+ * If you are looking for production-ready output files, see mode: "production" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (() => {
+  // webpackBootstrap
+  /******/ var __webpack_modules__ = {
+    /***/ "./index.js"(
+      /*!******************!*\
+  !*** ./index.js ***!
+  \******************/
+      __unused_webpack_module,
+      __unused_webpack_exports,
+      __webpack_require__,
+    ) {
+      eval(
+        '{__webpack_require__(/*! ./rules */ "./rules.js");\n__webpack_require__(/*! ./twice */ "./twice.js");\n\n\n//# sourceURL=webpack:///./index.js?\n}',
+      );
+
+      /***/
+    },
+
+    /***/ "./rules.js"(
+      /*!******************!*\
+  !*** ./rules.js ***!
+  \******************/
+      module,
+    ) {
+      eval(
+        "{const unused = 1;\n\ndebugger;\n\nmodule.exports = 2;\n\n\n//# sourceURL=webpack:///./rules.js?\n}",
+      );
+
+      /***/
+    },
+
+    /***/ "./twice.js"(
+      /*!******************!*\
+  !*** ./twice.js ***!
+  \******************/
+      module,
+    ) {
+      eval(
+        "{const first = 1;\n\nconst second = 2;\n\nmodule.exports = 3;\n\n\n//# sourceURL=webpack:///./twice.js?\n}",
+      );
+
+      /***/
+    },
+
+    /******/
+  };
+  /************************************************************************/
+  /******/ // The module cache
+  /******/ const __webpack_module_cache__ = {};
+  /******/
+  /******/ // The require function
+  /******/ function __webpack_require__(moduleId) {
+    /******/ // Check if module is in cache
+    /******/ const cachedModule = __webpack_module_cache__[moduleId];
+    /******/ if (cachedModule !== undefined) {
+      /******/ return cachedModule.exports;
+      /******/
+    }
+    /******/ // Create a new module (and put it into the cache)
+    /******/ const module = (__webpack_module_cache__[moduleId] = {
+      /******/ // no module.id needed
+      /******/ // no module.loaded needed
+      /******/ exports: {},
+      /******/
+    });
+    /******/
+    /******/ // Execute the module function
+    /******/ if (!(moduleId in __webpack_modules__)) {
+      /******/ delete __webpack_module_cache__[moduleId];
+      /******/ const e = new Error("Cannot find module '" + moduleId + "'");
+      /******/ e.code = "MODULE_NOT_FOUND";
+      /******/ throw e;
+      /******/
+    }
+    /******/ __webpack_modules__[moduleId](
+      module,
+      module.exports,
+      __webpack_require__,
+    );
+    /******/
+    /******/ // Return the exports of the module
+    /******/ return module.exports;
+    /******/
+  }
+  /******/
+  /************************************************************************/
+  /******/
+  /******/ // startup
+  /******/ // Load entry module and return exports
+  /******/ // This entry module can't be inlined because the eval devtool is used.
+  /******/ let __webpack_exports__ = __webpack_require__("./index.js");
+  /******/
+  /******/
+})();

--- a/test/oxlint/oxlint.test.js
+++ b/test/oxlint/oxlint.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
+
+describe("oxlint", () => {
+  it("should report nothing when the files are fine", async () => {
+    const stats = await pack("good").runAsync();
+
+    assert.strictEqual(stats.hasErrors(), false);
+    assert.strictEqual(stats.hasWarnings(), false);
+  });
+
+  it("should report what oxlint rates an error as one", async () => {
+    const stats = await pack("bad").runAsync();
+
+    assert.strictEqual(stats.hasErrors(), true);
+
+    const [{ message }] = stats.compilation.errors;
+
+    assert.match(message, /\[oxlint\]/u);
+    assert.match(message, /rules\.js:3:1/u);
+    assert.match(message, /no-debugger/u);
+  });
+
+  it("should report what oxlint rates a warning as one", async () => {
+    const stats = await pack("bad").runAsync();
+
+    assert.strictEqual(stats.hasWarnings(), true);
+
+    const [{ message }] = stats.compilation.warnings;
+
+    assert.match(message, /no-unused-vars/u);
+    assert.doesNotMatch(message, /no-debugger/u);
+  });
+
+  it("should keep every problem a file holds, not the last of them", async () => {
+    const stats = await pack("bad").runAsync();
+    const [{ message }] = stats.compilation.warnings;
+
+    // One result carries a file's diagnostics, so two in one file both survive
+    // being remembered under that file.
+    assert.match(message, /twice\.js:1:7/u);
+    assert.match(message, /twice\.js:3:7/u);
+  });
+
+  it("should let reportAs send both to warnings", async () => {
+    const stats = await pack("bad", { reportAs: "warning" }).runAsync();
+
+    assert.strictEqual(stats.hasErrors(), false);
+    assert.strictEqual(stats.hasWarnings(), true);
+  });
+
+  it("should format with a formatter written in the configuration", async () => {
+    const stats = await pack("bad", {
+      formatter: (results) =>
+        `saw ${results.length} file(s), first holds ${results[0].diagnostics.length}`,
+    }).runAsync();
+
+    assert.match(stats.compilation.errors[0].message, /saw 1 file\(s\)/u);
+  });
+
+  it("should leave oxlint to refuse a format of one's own", async () => {
+    // The check reads oxlint's JSON, and oxlint itself declines to be asked
+    // twice rather than answering in something this cannot read.
+    const stats = await pack("bad", {
+      args: ["--format=stylish"],
+    }).runAsync();
+
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.match(stats.compilation.errors[0].message, /--format/u);
+  });
+
+  it("should say so when oxlint refuses to run", async () => {
+    const stats = await pack("bad", { args: ["--not-a-flag"] }).runAsync();
+
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.match(stats.compilation.errors[0].message, /\[oxlint\]/u);
+  });
+
+  it("should say so when it cannot be found", async () => {
+    const stats = await pack("bad", { oxlintPath: "not-a-linter" }).runAsync();
+
+    assert.strictEqual(stats.hasErrors(), true);
+    assert.match(stats.compilation.errors[0].message, /not-a-linter/u);
+  });
+});

--- a/test/oxlint/utils/conf.js
+++ b/test/oxlint/utils/conf.js
@@ -1,0 +1,34 @@
+import { join } from "node:path";
+
+import DiagnosticsPlugin from "../../../src/index.js";
+
+// Options the plugin only accepts next to the check entries, not inside one.
+const PLUGIN_OPTIONS = ["context", "lintOnStart", "threads"];
+
+export default (context, pluginConf = {}, webpackConf = {}) => {
+  const testDir = join(import.meta.dirname, "..");
+  const plugin = {};
+  const oxlint = {};
+
+  for (const [option, value] of Object.entries(pluginConf)) {
+    if (PLUGIN_OPTIONS.includes(option)) {
+      plugin[option] = value;
+    } else {
+      oxlint[option] = value;
+    }
+  }
+
+  return {
+    context: join(testDir, "fixtures", context),
+    mode: "development",
+    entry: "./index",
+    output: { path: join(testDir, "outputs") },
+    plugins: [
+      new DiagnosticsPlugin({
+        ...plugin,
+        checks: [{ use: "oxlint", ...oxlint }],
+      }),
+    ],
+    ...webpackConf,
+  };
+};

--- a/test/oxlint/utils/pack.js
+++ b/test/oxlint/utils/pack.js
@@ -1,0 +1,28 @@
+import webpack from "webpack";
+
+import conf from "./conf.js";
+
+export default (context, pluginConf = {}, webpackConf = {}) => {
+  const compiler = webpack(conf(context, pluginConf, webpackConf));
+
+  return {
+    get outputPath() {
+      return compiler.outputPath;
+    },
+
+    runAsync() {
+      return new Promise((resolve, reject) => {
+        compiler.run((err, stats) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(stats);
+          }
+        });
+      });
+    },
+    watch(options, fn) {
+      return compiler.watch(options, fn);
+    },
+  };
+};

--- a/types/checks/oxlint.d.ts
+++ b/types/checks/oxlint.d.ts
@@ -1,0 +1,66 @@
+declare namespace _default {
+  export let name: string;
+  export let label: string;
+  export let filesSource: string;
+  export const schema: any;
+  export namespace defaults {
+    let extensions: string[];
+  }
+  export function defaultExclude(): string;
+  export { create };
+  export function resultPath(result: EXPECTED_ANY): string;
+}
+export default _default;
+export type EXPECTED_ANY = any;
+export type CheckContext = import("./index.js").CheckContext;
+export type CheckInstance = import("./index.js").CheckInstance;
+export type Options = import("../options.js").CheckOptions;
+export type FileResult = {
+  /**
+   * the file every diagnostic of it was found in
+   */
+  filename: string;
+  /**
+   * what oxlint found there
+   */
+  diagnostics: Diagnostic[];
+};
+export type Diagnostic = {
+  /**
+   * what oxlint found
+   */
+  message: string;
+  /**
+   * the rule it came from
+   */
+  code?: string | undefined;
+  /**
+   * how oxlint rates it
+   */
+  severity: string;
+  /**
+   * the file it was found in
+   */
+  filename: string;
+  /**
+   * what oxlint suggests
+   */
+  help?: string | undefined;
+  /**
+   * where it is
+   */
+  labels?:
+    | {
+        label?: string;
+        span: {
+          line: number;
+          column: number;
+        };
+      }[]
+    | undefined;
+};
+/**
+ * @param {CheckContext} context check context
+ * @returns {Promise<CheckInstance>} oxlint check
+ */
+declare function create({ options }: CheckContext): Promise<CheckInstance>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The fourth check. Run it with `{ use: "oxlint" }`: it lints the files webpack builds, as the ESLint check does, and reports what oxlint found at oxlint's own severities — a rule set to `"error"` in `.oxlintrc.json` is a webpack error and one set to `"warn"` a warning, with [`reportAs`](https://github.com/webpack/diagnostics-webpack-plugin#reportas) moving them from there.

oxlint is a binary behind a Node entry rather than a library — `defineConfig` is all its package exports, which I checked before writing any of this — so the check runs it and reads the JSON it answers with, the same way the other bundlers' integrations reach it. Two consequences are documented rather than hidden: an argument list is not unbounded, so a batch past five hundred files is run in several; and the flags this check does not name go in `args` rather than being guessed at from option names.

**One thing the tests caught that the design did not.** oxlint answers one diagnostic per problem where a linter answers one result per file, and the plugin remembers a file by one result — so two problems in one file left only the last of them. Diagnostics are grouped per file before being handed over, and `test/oxlint/oxlint.test.js` has the case that failed.

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes — `test/oxlint/oxlint.test.js`, nine cases: a clean project reports nothing; an `"error"` rule becomes a webpack error naming file, line, column and rule; a `"warn"` rule becomes a warning and does not carry the error with it; two problems in one file both survive; `reportAs` moves both; a formatter written in the configuration is used; `--format` in `args` is left to oxlint to refuse; oxlint refusing to run is reported; and an `oxlintPath` naming nothing is reported.

**Does this PR introduce a breaking change?**

No. The check is opt-in and nothing else changes.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

`README.md` here: an `oxlint` section with `oxlintPath`, `configFile` and `args`, plus the intro and install lines. `oxlint >= 1` is an optional peer in `package.json`. The webpack.js.org page wants the section after release.

**Use of AI**

AI was used. Claude Code installed oxlint and probed its CLI before designing anything — which is how the JSON shape, the relative `filename`, the `"error"`/`"warning"` severities and the non-zero exit on findings are described from what it prints rather than from memory. It then wrote the adapter, the tests and the documentation, and ran the suite, lint, audit and both dist entry points. Rebased onto #327 after that merged, reconstructing the README section rather than resolving a line-level conflict that cut across two sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy)_