### PR TITLE
fix: watch the files a check reads

### DIFF
--- a/.changeset/watch-what-a-check-reads.md
+++ b/.changeset/watch-what-a-check-reads.md
@@ -1,0 +1,5 @@
+---
+"diagnostics-webpack-plugin": patch
+---
+
+Watch the files a check reads rather than only the ones webpack builds, so that a change to a file outside the module graph — one `stylelint` globs, or one a `tsconfig.json` lists — rebuilds, and a file added or removed there is picked up.

--- a/src/check.js
+++ b/src/check.js
@@ -9,8 +9,8 @@ import { toPosixPath } from "./utils.js";
 /** @typedef {import("./checks/index.js").CheckInstance} CheckInstance */
 /** @typedef {import("./options.js").EnabledCheck} EnabledCheck */
 /** @typedef {{ filePath: string, content: string }} OutputReportContent */
-/** @typedef {{ errors?: DiagnosticError, warnings?: DiagnosticError, outputReport?: OutputReportContent }} Report */
-/** @typedef {{ lint: (files: string[]) => void, keep: (files: string[]) => void, keepKnown: (removed: ReadonlySet<string>) => void, report: () => Promise<Report> }} Runner */
+/** @typedef {{ read: string[], errors?: DiagnosticError, warnings?: DiagnosticError, outputReport?: OutputReportContent }} Report */
+/** @typedef {{ lint: (files: string[]) => void, keep: (files: string[]) => void, report: () => Promise<Report> }} Runner */
 /** @typedef {Map<string, CheckResult | undefined>} ResultStore */
 
 /** @type {WeakMap<Compilation["compiler"], Map<string, ResultStore>>} */
@@ -81,6 +81,10 @@ function createCheckRunner(key, { name, adapter, options }, compilation) {
   const { resultPath } = adapter;
   /** @type {Set<string>} */
   const covered = new Set();
+  // Kept as the check was given them rather than as the store keys them: these
+  // are handed back to webpack, which compares paths the way the platform does.
+  /** @type {Set<string>} */
+  const read = new Set();
   /** @type {Set<string>} */
   const linted = new Set();
   // A check that cannot lint fails the same way for every batch it is given.
@@ -93,6 +97,7 @@ function createCheckRunner(key, { name, adapter, options }, compilation) {
     for (const file of files) {
       const known = toPosixPath(file);
 
+      read.add(file);
       covered.add(known);
       linted.add(known);
     }
@@ -130,27 +135,13 @@ function createCheckRunner(key, { name, adapter, options }, compilation) {
     for (const file of files) {
       const known = toPosixPath(file);
 
+      read.add(file);
+
       if (store.has(known)) covered.add(known);
       else unknown.push(file);
     }
 
     if (unknown.length > 0) lint(unknown);
-  }
-
-  /**
-   * Keeps every file the last compilation covered bar the ones webpack says
-   * are gone — what a check that walks the file system knows about the files
-   * it is not being told changed, without walking it again.
-   * @param {ReadonlySet<string>} removed the files webpack no longer sees
-   */
-  function keepKnown(removed) {
-    if (!resultPath) return;
-
-    const gone = new Set([...removed].map((file) => toPosixPath(file)));
-
-    for (const file of store.keys()) {
-      if (!gone.has(file)) covered.add(file);
-    }
   }
 
   /**
@@ -198,10 +189,16 @@ function createCheckRunner(key, { name, adapter, options }, compilation) {
   async function report() {
     const instance = await pending;
 
-    if (!instance) return {};
+    if (!instance) return { read: [...read] };
 
     // Get the current results, resetting the raw results to empty.
     const raw = await flatten(rawResults.splice(0));
+
+    // A check reading more than it was handed — a config file, a project the
+    // graph does not describe — says so before anything is released.
+    if (instance.readFiles) {
+      for (const file of instance.readFiles()) read.add(file);
+    }
 
     await instance.cleanup();
 
@@ -209,14 +206,14 @@ function createCheckRunner(key, { name, adapter, options }, compilation) {
 
     // Do not analyze when the check reported nothing.
     if (!results || results.length === 0) {
-      return {};
+      return { read: [...read] };
     }
 
     const format = await instance.getFormatter(options.formatter);
     const { errors, warnings } = instance.splitResults(results);
 
     /** @type {Report} */
-    const report = {};
+    const report = { read: [...read] };
 
     // What `reportAs` drops is not formatted at all, but an `outputReport` is
     // still written from all of the results below.
@@ -246,7 +243,7 @@ function createCheckRunner(key, { name, adapter, options }, compilation) {
     return report;
   }
 
-  return { keep, keepKnown, lint, report };
+  return { keep, lint, report };
 }
 
 export default createCheckRunner;

--- a/src/checks/index.js
+++ b/src/checks/index.js
@@ -35,6 +35,7 @@ import typescript from "./typescript.js";
  * @property {(results: CheckResult[]) => Promise<CheckResult[]>} getResults turns the raw results of every `lintFiles` call into the results to report
  * @property {(results: CheckResult[]) => { errors: CheckResult[], warnings: CheckResult[] }} splitResults splits the results by their own severity, leaving `reportAs` to the plugin
  * @property {((result: CheckResult) => string | undefined)=} resultPath the file a result came from, without which a rebuild re-lints everything
+ * @property {(() => string[])=} readFiles the files the check read beyond the ones it was handed, so that a watcher picks up a change to them
  * @property {(formatter?: FormatterOption) => Promise<Format>} getFormatter loads a formatter, falling back to the tool's default one
  * @property {() => Promise<void>} cleanup releases whatever the tool holds after a run
  */

--- a/src/checks/typescript.js
+++ b/src/checks/typescript.js
@@ -52,7 +52,7 @@ function getTypeScriptOptions(options) {
  * output, so a check that wrote any of its own would fight it.
  * @param {TypeScript} ts the loaded TypeScript
  * @param {Options} options options
- * @returns {{ diagnostics: Diagnostic[], host: EXPECTED_ANY }} what it found
+ * @returns {{ diagnostics: Diagnostic[], host: EXPECTED_ANY, files: string[] }} what it found, and what it read to find it
  */
 function check(ts, options) {
   const context = String(options.context);
@@ -92,13 +92,17 @@ function check(ts, options) {
     ) => unrecoverable.push(diagnostic),
   });
 
-  if (!parsed) return { diagnostics: unrecoverable, host };
+  if (!parsed) return { diagnostics: unrecoverable, host, files: [configFile] };
 
   const program = ts.createProgram({
     rootNames: parsed.fileNames,
     options: parsed.options,
     projectReferences: parsed.projectReferences,
   });
+
+  const extended = parsed.options.configFile
+    ? parsed.options.configFile.extendedSourceFiles || []
+    : [];
 
   return {
     diagnostics: [
@@ -107,6 +111,9 @@ function check(ts, options) {
       ...ts.getPreEmitDiagnostics(program),
     ],
     host,
+    // The config file decides which files the program holds, so reading it
+    // again is what a change to it takes.
+    files: [configFile, ...extended, ...parsed.fileNames],
   };
 }
 
@@ -121,6 +128,8 @@ async function create({ options }) {
 
   /** @type {EXPECTED_ANY} */
   let host;
+  /** @type {string[]} */
+  let read = [];
   // The program is the whole project, so it is built once however many batches
   // of files the plugin hands over.
   let checked = false;
@@ -134,8 +143,12 @@ async function create({ options }) {
       const found = check(typescript, options);
 
       host = found.host;
+      read = found.files;
 
       return found.diagnostics;
+    },
+    readFiles() {
+      return read;
     },
     async getResults(results) {
       return results;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, normalize } from "node:path";
 
 import picomatch from "picomatch";
 import { globSync } from "tinyglobby";
@@ -321,8 +321,12 @@ class DiagnosticsWebpackPlugin {
               await runner.report();
 
             // Webpack watches what it built; a check reads what it was
-            // configured to, which is not always the same set of files.
-            for (const file of read) compilation.fileDependencies.add(file);
+            // configured to, which is not always the same set of files. Each
+            // one is spelled the way the platform does: a watcher looks a
+            // change up under the path it joined, not the one it was given.
+            for (const file of read) {
+              compilation.fileDependencies.add(normalize(file));
+            }
 
             // `reportAs` has already dropped whatever it reports as `false`,
             // so what is left only needs putting where it belongs.

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import {
   arrify,
   parseFiles,
   parseFoldersToGlobs,
+  toPosixPath,
   writeOutputFile,
 } from "./utils.js";
 
@@ -42,22 +43,35 @@ const EARLY_BATCH = 64;
 let compilerId = 0;
 
 /**
+ * Walks the file system for the files a check wants, and says which of them
+ * webpack has just seen change.
  * @param {Compiler} compiler compiler
  * @param {ResolvedCheck} check the check to collect the files of
- * @returns {string[]} the files on disk to lint
+ * @returns {{ lint: string[], keep: string[] }} the files to lint, and the ones to report from the last compilation
  */
-function collectFromFileSystem(compiler, { wanted, exclude, ...check }) {
+function collectFromFileSystem(compiler, { adapter, wanted, exclude }) {
+  // The walk is what says which files there are: one webpack never built is
+  // one it cannot report as added, changed or gone either.
+  const found = globSync(wanted, {
+    absolute: true,
+    dot: true,
+    ignore: exclude,
+  });
   const { modifiedFiles } = compiler;
 
   // A check that cannot say which file a result came from has nothing to report
   // a file it was not given from, so it is given all of them every time.
-  if (!modifiedFiles || !check.adapter.resultPath) {
-    return globSync(wanted, { absolute: true, dot: true, ignore: exclude });
+  if (!modifiedFiles || !adapter.resultPath) return { lint: found, keep: [] };
+
+  const changed = new Set([...modifiedFiles].map((file) => toPosixPath(file)));
+  /** @type {{ lint: string[], keep: string[] }} */
+  const collected = { lint: [], keep: [] };
+
+  for (const file of found) {
+    collected[changed.has(toPosixPath(file)) ? "lint" : "keep"].push(file);
   }
 
-  return [...modifiedFiles].filter(
-    (file) => check.isWanted(file) && !check.isExcluded(file),
-  );
+  return collected;
 }
 
 class DiagnosticsWebpackPlugin {
@@ -285,15 +299,10 @@ class DiagnosticsWebpackPlugin {
       for (const check of runners) {
         if (check.adapter.filesSource === "modules") continue;
 
-        const files = collectFromFileSystem(compiler, check);
+        const collected = collectFromFileSystem(compiler, check);
 
-        if (files.length > 0) check.runner.lint(files);
-
-        // A rebuild is told what changed rather than what exists, so the rest
-        // of what the walk found last time is reported from there.
-        if (compiler.modifiedFiles) {
-          check.runner.keepKnown(compiler.removedFiles || new Set());
-        }
+        if (collected.lint.length > 0) check.runner.lint(collected.lint);
+        if (collected.keep.length > 0) check.runner.keep(collected.keep);
       }
 
       compilation.hooks.finishModules.tap(this.key, () => {
@@ -308,7 +317,12 @@ class DiagnosticsWebpackPlugin {
           const outputReports = new Map();
 
           for (const { options, runner } of runners) {
-            const { errors, warnings, outputReport } = await runner.report();
+            const { errors, warnings, outputReport, read } =
+              await runner.report();
+
+            // Webpack watches what it built; a check reads what it was
+            // configured to, which is not always the same set of files.
+            for (const file of read) compilation.fileDependencies.add(file);
 
             // `reportAs` has already dropped whatever it reports as `false`,
             // so what is left only needs putting where it belongs.

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -68,21 +68,20 @@ describe("store", () => {
     assert.deepStrictEqual(await reported(second), [win32("a.css")]);
   });
 
-  it("should drop a removed file whatever webpack spells it with", async () => {
-    // A glob check walks the file system for forward slashes and is told what
-    // changed in the separators the platform uses.
+  it("should drop a file it is no longer handed", async () => {
     const compiler = { outputPath: "/out" };
-    const walked = "C:/project/a.css";
-    const first = runnerFor(adapterFinding([walked]), compiler);
+    const dirty = [win32("a.css"), win32("b.css")];
+    const first = runnerFor(adapterFinding(dirty), compiler);
 
-    first.lint([walked]);
+    first.lint(dirty);
 
-    assert.deepStrictEqual(await reported(first), [walked]);
+    assert.deepStrictEqual(await reported(first), dirty);
 
     const second = runnerFor(adapterFinding([]), compiler);
 
-    second.keepKnown(new Set([win32("a.css")]));
+    // Nothing says a file was removed: what the walk no longer finds is gone.
+    second.keep([win32("a.css")]);
 
-    assert.deepStrictEqual(await reported(second), []);
+    assert.deepStrictEqual(await reported(second), [win32("a.css")]);
   });
 });

--- a/test/stylelint/fixtures/unbuilt/index.js
+++ b/test/stylelint/fixtures/unbuilt/index.js
@@ -1,0 +1,1 @@
+require("./trigger");

--- a/test/stylelint/unbuilt.test.js
+++ b/test/stylelint/unbuilt.test.js
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
+
+const fixture = join(import.meta.dirname, "fixtures", "unbuilt");
+const orphan = join(fixture, "orphan.scss");
+// Something webpack does build, so that a rebuild can be asked for without
+// touching the file under test.
+const trigger = join(fixture, "trigger.js");
+
+describe("unbuilt", () => {
+  let watch;
+
+  afterEach(() => {
+    if (watch) {
+      watch.close();
+    }
+    rmSync(orphan, { force: true });
+    rmSync(trigger, { force: true });
+  });
+
+  it("should rebuild when a file webpack never built changes", (t, done) => {
+    writeFileSync(trigger, "const trigger = 1;\n");
+    writeFileSync(orphan, "#orphan { color: black; }\n");
+
+    // eslint-disable-next-line no-use-before-define
+    let next = firstPass;
+    const compiler = pack("unbuilt");
+
+    watch = compiler.watch({}, (err, stats) => next(err, stats));
+
+    function secondPass(err, stats) {
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasErrors(), false);
+      done();
+    }
+
+    function firstPass(err, stats) {
+      assert.strictEqual(err, null);
+
+      const [{ message }] = stats.compilation.errors;
+
+      assert.match(message, /orphan\.scss/u);
+
+      next = secondPass;
+      writeFileSync(orphan, "#orphan { color: #000000; }\n");
+    }
+  });
+
+  it("should find a file that appears after the watch started", (t, done) => {
+    writeFileSync(trigger, "const trigger = 1;\n");
+
+    // eslint-disable-next-line no-use-before-define
+    let next = firstPass;
+    const compiler = pack("unbuilt");
+
+    watch = compiler.watch({}, (err, stats) => next(err, stats));
+
+    function secondPass(err, stats) {
+      assert.strictEqual(err, null);
+
+      const [{ message }] = stats.compilation.errors;
+
+      assert.match(message, /orphan\.scss/u);
+      done();
+    }
+
+    function firstPass(err, stats) {
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasErrors(), false);
+
+      next = secondPass;
+      writeFileSync(orphan, "#orphan { color: black; }\n");
+      writeFileSync(trigger, "const trigger = 2;\n");
+    }
+  });
+
+  it("should stop reporting a file that is gone", (t, done) => {
+    writeFileSync(trigger, "const trigger = 1;\n");
+    writeFileSync(orphan, "#orphan { color: black; }\n");
+
+    // eslint-disable-next-line no-use-before-define
+    let next = firstPass;
+    const compiler = pack("unbuilt");
+
+    watch = compiler.watch({}, (err, stats) => next(err, stats));
+
+    function secondPass(err, stats) {
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasErrors(), false);
+      done();
+    }
+
+    function firstPass(err, stats) {
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasErrors(), true);
+
+      next = secondPass;
+      rmSync(orphan, { force: true });
+      writeFileSync(trigger, "const trigger = 2;\n");
+    }
+  });
+});

--- a/test/stylelint/unbuilt.test.js
+++ b/test/stylelint/unbuilt.test.js
@@ -11,6 +11,9 @@ const orphan = join(fixture, "orphan.scss");
 // touching the file under test.
 const trigger = join(fixture, "trigger.js");
 
+// Webpack starts a rebuild of its own for a file these tests wrote just before
+// the watch began, so each one waits for the state it is after rather than
+// counting the passes up to it. A state that never arrives ends as a timeout.
 describe("unbuilt", () => {
   let watch;
 
@@ -26,81 +29,82 @@ describe("unbuilt", () => {
     writeFileSync(trigger, "const trigger = 1;\n");
     writeFileSync(orphan, "#orphan { color: black; }\n");
 
-    // eslint-disable-next-line no-use-before-define
-    let next = firstPass;
     const compiler = pack("unbuilt");
+    let fixing = true;
 
-    watch = compiler.watch({}, (err, stats) => next(err, stats));
-
-    function secondPass(err, stats) {
+    watch = compiler.watch({}, (err, stats) => {
       assert.strictEqual(err, null);
-      assert.strictEqual(stats.hasErrors(), false);
+
+      if (fixing) {
+        const [{ message }] = stats.compilation.errors;
+
+        assert.match(message, /orphan\.scss/u);
+
+        fixing = false;
+        writeFileSync(orphan, "#orphan { color: #000000; }\n");
+
+        return;
+      }
+
+      if (stats.hasErrors()) return;
+
       done();
-    }
-
-    function firstPass(err, stats) {
-      assert.strictEqual(err, null);
-
-      const [{ message }] = stats.compilation.errors;
-
-      assert.match(message, /orphan\.scss/u);
-
-      next = secondPass;
-      writeFileSync(orphan, "#orphan { color: #000000; }\n");
-    }
+    });
   });
 
   it("should find a file that appears after the watch started", (t, done) => {
     writeFileSync(trigger, "const trigger = 1;\n");
 
-    // eslint-disable-next-line no-use-before-define
-    let next = firstPass;
     const compiler = pack("unbuilt");
+    let creating = true;
 
-    watch = compiler.watch({}, (err, stats) => next(err, stats));
-
-    function secondPass(err, stats) {
+    watch = compiler.watch({}, (err, stats) => {
       assert.strictEqual(err, null);
+
+      if (creating) {
+        assert.strictEqual(stats.hasErrors(), false);
+
+        creating = false;
+        writeFileSync(orphan, "#orphan { color: black; }\n");
+        writeFileSync(trigger, "const trigger = 2;\n");
+
+        return;
+      }
+
+      if (!stats.hasErrors()) return;
 
       const [{ message }] = stats.compilation.errors;
 
       assert.match(message, /orphan\.scss/u);
       done();
-    }
-
-    function firstPass(err, stats) {
-      assert.strictEqual(err, null);
-      assert.strictEqual(stats.hasErrors(), false);
-
-      next = secondPass;
-      writeFileSync(orphan, "#orphan { color: black; }\n");
-      writeFileSync(trigger, "const trigger = 2;\n");
-    }
+    });
   });
 
   it("should stop reporting a file that is gone", (t, done) => {
     writeFileSync(trigger, "const trigger = 1;\n");
     writeFileSync(orphan, "#orphan { color: black; }\n");
 
-    // eslint-disable-next-line no-use-before-define
-    let next = firstPass;
     const compiler = pack("unbuilt");
+    let removing = true;
 
-    watch = compiler.watch({}, (err, stats) => next(err, stats));
-
-    function secondPass(err, stats) {
+    watch = compiler.watch({}, (err, stats) => {
       assert.strictEqual(err, null);
-      assert.strictEqual(stats.hasErrors(), false);
+
+      if (removing) {
+        const [{ message }] = stats.compilation.errors;
+
+        assert.match(message, /orphan\.scss/u);
+
+        removing = false;
+        rmSync(orphan, { force: true });
+        writeFileSync(trigger, "const trigger = 2;\n");
+
+        return;
+      }
+
+      if (stats.hasErrors()) return;
+
       done();
-    }
-
-    function firstPass(err, stats) {
-      assert.strictEqual(err, null);
-      assert.strictEqual(stats.hasErrors(), true);
-
-      next = secondPass;
-      rmSync(orphan, { force: true });
-      writeFileSync(trigger, "const trigger = 2;\n");
-    }
+    });
   });
 });

--- a/test/typescript/fixtures/watch/index.js
+++ b/test/typescript/fixtures/watch/index.js
@@ -1,0 +1,1 @@
+import "./trigger.js";

--- a/test/typescript/watch.test.js
+++ b/test/typescript/watch.test.js
@@ -34,6 +34,9 @@ function writeConfig(strict) {
   );
 }
 
+// Webpack starts a rebuild of its own for a file these tests wrote just before
+// the watch began, so each one waits for the state it is after rather than
+// counting the passes up to it. A state that never arrives ends as a timeout.
 describe("watch", () => {
   let watch;
 
@@ -51,29 +54,28 @@ describe("watch", () => {
     writeFileSync(trigger, "export const trigger = 1;\n");
     writeFileSync(orphan, "export const wrong: string = 42;\n");
 
-    // eslint-disable-next-line no-use-before-define
-    let next = firstPass;
     const compiler = pack("watch");
+    let fixing = true;
 
-    watch = compiler.watch({}, (err, stats) => next(err, stats));
-
-    function secondPass(err, stats) {
+    watch = compiler.watch({}, (err, stats) => {
       assert.strictEqual(err, null);
-      assert.strictEqual(stats.hasErrors(), false);
+
+      if (fixing) {
+        const [{ message }] = stats.compilation.errors;
+
+        assert.match(message, /orphan\.ts/u);
+        assert.match(message, /TS2322/u);
+
+        fixing = false;
+        writeFileSync(orphan, "export const wrong: number = 42;\n");
+
+        return;
+      }
+
+      if (stats.hasErrors()) return;
+
       done();
-    }
-
-    function firstPass(err, stats) {
-      assert.strictEqual(err, null);
-
-      const [{ message }] = stats.compilation.errors;
-
-      assert.match(message, /orphan\.ts/u);
-      assert.match(message, /TS2322/u);
-
-      next = secondPass;
-      writeFileSync(orphan, "export const wrong: number = 42;\n");
-    }
+    });
   });
 
   it("should rebuild when the config file changes", (t, done) => {
@@ -81,14 +83,22 @@ describe("watch", () => {
     writeFileSync(trigger, "export const trigger = 1;\n");
     writeFileSync(orphan, "export const same = (value) => value;\n");
 
-    // eslint-disable-next-line no-use-before-define
-    let next = firstPass;
     const compiler = pack("watch");
+    let tightening = true;
 
-    watch = compiler.watch({}, (err, stats) => next(err, stats));
-
-    function secondPass(err, stats) {
+    watch = compiler.watch({}, (err, stats) => {
       assert.strictEqual(err, null);
+
+      if (tightening) {
+        assert.strictEqual(stats.hasErrors(), false);
+
+        tightening = false;
+        writeConfig(true);
+
+        return;
+      }
+
+      if (!stats.hasErrors()) return;
 
       const [{ message }] = stats.compilation.errors;
 
@@ -96,14 +106,6 @@ describe("watch", () => {
       assert.match(message, /orphan\.ts/u);
       assert.match(message, /TS7006/u);
       done();
-    }
-
-    function firstPass(err, stats) {
-      assert.strictEqual(err, null);
-      assert.strictEqual(stats.hasErrors(), false);
-
-      next = secondPass;
-      writeConfig(true);
-    }
+    });
   });
 });

--- a/test/typescript/watch.test.js
+++ b/test/typescript/watch.test.js
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import pack from "./utils/pack.js";
+
+const fixture = join(import.meta.dirname, "fixtures", "watch");
+const orphan = join(fixture, "orphan.ts");
+const configFile = join(fixture, "tsconfig.json");
+// Something webpack does build, so that a rebuild can be asked for without
+// touching the files under test.
+const trigger = join(fixture, "trigger.js");
+
+/**
+ * @param {boolean} strict whether the project is checked strictly
+ */
+function writeConfig(strict) {
+  writeFileSync(
+    configFile,
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          strict,
+          target: "es2022",
+          module: "preserve",
+          skipLibCheck: true,
+        },
+        include: ["*.ts"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+describe("watch", () => {
+  let watch;
+
+  afterEach(() => {
+    if (watch) {
+      watch.close();
+    }
+    rmSync(orphan, { force: true });
+    rmSync(configFile, { force: true });
+    rmSync(trigger, { force: true });
+  });
+
+  it("should rebuild when a file only the program holds changes", (t, done) => {
+    writeConfig(true);
+    writeFileSync(trigger, "export const trigger = 1;\n");
+    writeFileSync(orphan, "export const wrong: string = 42;\n");
+
+    // eslint-disable-next-line no-use-before-define
+    let next = firstPass;
+    const compiler = pack("watch");
+
+    watch = compiler.watch({}, (err, stats) => next(err, stats));
+
+    function secondPass(err, stats) {
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasErrors(), false);
+      done();
+    }
+
+    function firstPass(err, stats) {
+      assert.strictEqual(err, null);
+
+      const [{ message }] = stats.compilation.errors;
+
+      assert.match(message, /orphan\.ts/u);
+      assert.match(message, /TS2322/u);
+
+      next = secondPass;
+      writeFileSync(orphan, "export const wrong: number = 42;\n");
+    }
+  });
+
+  it("should rebuild when the config file changes", (t, done) => {
+    writeConfig(false);
+    writeFileSync(trigger, "export const trigger = 1;\n");
+    writeFileSync(orphan, "export const same = (value) => value;\n");
+
+    // eslint-disable-next-line no-use-before-define
+    let next = firstPass;
+    const compiler = pack("watch");
+
+    watch = compiler.watch({}, (err, stats) => next(err, stats));
+
+    function secondPass(err, stats) {
+      assert.strictEqual(err, null);
+
+      const [{ message }] = stats.compilation.errors;
+
+      // The file did not change; what the config file asks of it did.
+      assert.match(message, /orphan\.ts/u);
+      assert.match(message, /TS7006/u);
+      done();
+    }
+
+    function firstPass(err, stats) {
+      assert.strictEqual(err, null);
+      assert.strictEqual(stats.hasErrors(), false);
+
+      next = secondPass;
+      writeConfig(true);
+    }
+  });
+});

--- a/types/check.d.ts
+++ b/types/check.d.ts
@@ -8,6 +8,7 @@ export type OutputReportContent = {
   content: string;
 };
 export type Report = {
+  read: string[];
   errors?: DiagnosticError;
   warnings?: DiagnosticError;
   outputReport?: OutputReportContent;
@@ -15,7 +16,6 @@ export type Report = {
 export type Runner = {
   lint: (files: string[]) => void;
   keep: (files: string[]) => void;
-  keepKnown: (removed: ReadonlySet<string>) => void;
   report: () => Promise<Report>;
 };
 export type ResultStore = Map<string, CheckResult | undefined>;

--- a/types/checks/index.d.ts
+++ b/types/checks/index.d.ts
@@ -49,6 +49,10 @@ export type CheckInstance = {
    */
   resultPath?: ((result: CheckResult) => string | undefined) | undefined;
   /**
+   * the files the check read beyond the ones it was handed, so that a watcher picks up a change to them
+   */
+  readFiles?: (() => string[]) | undefined;
+  /**
    * loads a formatter, falling back to the tool's default one
    */
   getFormatter: (formatter?: FormatterOption) => Promise<Format>;
@@ -164,6 +168,7 @@ export type CheckAdapter = {
  * @property {(results: CheckResult[]) => Promise<CheckResult[]>} getResults turns the raw results of every `lintFiles` call into the results to report
  * @property {(results: CheckResult[]) => { errors: CheckResult[], warnings: CheckResult[] }} splitResults splits the results by their own severity, leaving `reportAs` to the plugin
  * @property {((result: CheckResult) => string | undefined)=} resultPath the file a result came from, without which a rebuild re-lints everything
+ * @property {(() => string[])=} readFiles the files the check read beyond the ones it was handed, so that a watcher picks up a change to them
  * @property {(formatter?: FormatterOption) => Promise<Format>} getFormatter loads a formatter, falling back to the tool's default one
  * @property {() => Promise<void>} cleanup releases whatever the tool holds after a run
  */


### PR DESCRIPTION
**Summary**

A check is not limited to what webpack built — `stylelint` walks `files` for every stylesheet there is, and `typescript` asks a `tsconfig.json` for its program — and nothing told webpack about any of those files. Editing one rebuilt nothing, so the error it left behind stood until something else happened to trigger a build.

Every file a check was handed is now a `fileDependency` of the compilation, and a rebuild walks the file system again rather than intersecting `modifiedFiles` with the globs: the walk is the only thing that knows a file has appeared or gone, neither of which webpack can report for a file it never watched. That costs one walk per rebuild — 4 ms over webpack's own `lib/`, 729 files — and the linting itself stays incremental, so what is kept from the previous compilation is unchanged. `keepKnown` goes with it, along with its reading of `removedFiles`.

`CheckInstance` gains an optional `readFiles`, for a check whose files are not the ones it was given: the `typescript` check answers with its config file, whatever that extends, and the program's own file set, so a change to the configuration is picked up as well as one to a file it lists.

**What kind of change does this PR introduce?**

fix

**Did you add tests for your changes?**

Yes — `test/stylelint/unbuilt.test.js` (a file webpack never built rebuilds when changed, is found when created, and stops being reported when gone) and `test/typescript/watch.test.js` (a file only the program holds, and the config file itself); all five hang or fail on `main`. `test/store.test.js` covers the runner without `keepKnown`.

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

n/a — `readFiles` is documented on the `CheckInstance` typedef for anyone shipping a check outside this package.

**Use of AI**

Claude Code wrote this change, guided and reviewed commit by commit by me. The hole was demonstrated with a measured A/B on a real watch build before anything was written, and the walk's cost was measured rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy)_