### PR TITLE
feat: reportAs can log a check rather than report it

### DIFF
--- a/.changeset/report-as-log.md
+++ b/.changeset/report-as-log.md
@@ -1,0 +1,5 @@
+---
+"diagnostics-webpack-plugin": minor
+---
+
+Add `"log"` to `reportAs`, which writes a check's results to webpack's log rather than onto the compilation, so they reach the terminal without the build carrying an error or a warning.

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Every check reports its errors as webpack errors and its warnings as webpack war
 
 ```ts
 type reportAs = Severity | { errors?: Severity; warnings?: Severity };
-type Severity = "error" | "warning" | false;
+type Severity = "error" | "warning" | "log" | false;
 ```
 
 - Default: unset — each result stays at the severity the check gave it
@@ -326,6 +326,7 @@ What a check reports its results as. One value covers its errors and its warning
 | unset                   | Errors fail the build, warnings do not.                    |
 | `"error"`               | Everything fails the build, warnings included.             |
 | `"warning"`             | Nothing fails the build; errors are reported as warnings.  |
+| `"log"`                 | The terminal alone, through webpack's log.                 |
 | `false`                 | Nothing is reported. An `outputReport` is still written.   |
 | `{ warnings: false }`   | The errors alone, still failing the build.                 |
 | `{ warnings: "error" }` | Warnings fail the build too, and errors keep failing it.   |
@@ -335,6 +336,19 @@ What a check reports its results as. One value covers its errors and its warning
 new DiagnosticsPlugin({
   reportAs: { warnings: false }, // the errors alone
   checks: [{ use: "eslint" }],
+});
+```
+
+`"log"` is for a check nobody should be stopped by yet. Its results reach
+webpack's log — the terminal, and `stats.logging` — rather than
+`compilation.errors` or `compilation.warnings`, so the build carries neither,
+`stats.hasWarnings()` stays false and a dev server overlays nothing. An
+`outputReport` is written either way.
+
+```js
+new DiagnosticsPlugin({
+  // the whole project is linted, and only the new check is advisory
+  checks: [{ use: "eslint" }, { use: "typescript", reportAs: "log" }],
 });
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -338,6 +338,18 @@ class DiagnosticsWebpackPlugin {
 
               const severity = reportedAs(options.reportAs, results);
 
+              // Logged rather than reported: the terminal shows it, the build
+              // carries neither an error nor a warning, and a dev server has
+              // nothing to overlay.
+              if (severity === "log") {
+                const logger = compilation.getLogger(LINT_PLUGIN);
+
+                if (results === "errors") logger.error(reported.message);
+                else logger.warn(reported.message);
+
+                continue;
+              }
+
               (severity === "error"
                 ? compilation.errors
                 : compilation.warnings

--- a/src/options.js
+++ b/src/options.js
@@ -13,7 +13,7 @@ const nodeRequire = createRequire(import.meta.url);
 const PLUGIN_NAME = "Diagnostics Webpack Plugin";
 
 /** @typedef {import("webpack").Compiler} Compiler */
-/** @typedef {"error" | "warning" | false} Severity */
+/** @typedef {"error" | "warning" | "log" | false} Severity */
 /** @typedef {"errors" | "warnings"} Results */
 /** @typedef {number | boolean | "auto"} Threads */
 /** @typedef {Severity | { errors?: Severity, warnings?: Severity }} ReportAs */

--- a/src/shared-options.json
+++ b/src/shared-options.json
@@ -98,10 +98,10 @@
       ]
     },
     "reportAs": {
-      "description": "What a check reports its results as: `\"error\"` reports them as webpack errors and fails the build, `\"warning\"` reports them as webpack warnings, `false` reports nothing. One value covers a check's errors and its warnings alike, an object sets them apart, and a severity an object leaves out keeps its own.",
+      "description": "What a check reports its results as: `\"error\"` reports them as webpack errors and fails the build, `\"warning\"` reports them as webpack warnings, `\"log\"` writes them to the log and leaves the build carrying neither, `false` reports nothing. One value covers a check's errors and its warnings alike, an object sets them apart, and a severity an object leaves out keeps its own.",
       "anyOf": [
         {
-          "enum": ["error", "warning", false]
+          "enum": ["error", "warning", "log", false]
         },
         {
           "type": "object",
@@ -109,11 +109,11 @@
           "properties": {
             "errors": {
               "description": "What a check's errors are reported as, or `false` to drop them.",
-              "enum": ["error", "warning", false]
+              "enum": ["error", "warning", "log", false]
             },
             "warnings": {
               "description": "What a check's warnings are reported as, or `false` to drop them.",
-              "enum": ["error", "warning", false]
+              "enum": ["error", "warning", "log", false]
             }
           }
         }

--- a/test/report-as.test.js
+++ b/test/report-as.test.js
@@ -1,7 +1,19 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import pack from "./utils/pack.js";
+
+const PLUGIN = "DiagnosticsWebpackPlugin";
+
+/**
+ * @param {EXPECTED_ANY} stats the stats of a finished build
+ * @returns {EXPECTED_ANY[]} what the plugin wrote to the compilation's log
+ */
+function logging(stats) {
+  return stats.compilation.logging.get(PLUGIN) || [];
+}
 
 describe("report as", () => {
   it("should leave each result at its own severity by default", async () => {
@@ -43,6 +55,53 @@ describe("report as", () => {
 
     assert.strictEqual(stats.hasErrors(), false);
     assert.strictEqual(stats.hasWarnings(), false);
+  });
+
+  it("should log rather than report what is set to log", async () => {
+    const stats = await pack("full-of-problems", {
+      reportAs: "log",
+    }).runAsync();
+
+    assert.strictEqual(stats.hasErrors(), false);
+    assert.strictEqual(stats.hasWarnings(), false);
+
+    const logged = logging(stats);
+
+    assert.strictEqual(logged.length, 2);
+    assert.deepStrictEqual(
+      logged.map(({ type }) => type),
+      ["error", "warn"],
+    );
+    assert.match(logged[0].args[0], /\[eslint\]/u);
+  });
+
+  it("should log one severity and report the other", async () => {
+    const stats = await pack("full-of-problems", {
+      reportAs: { errors: "log" },
+    }).runAsync();
+
+    assert.strictEqual(stats.hasErrors(), false);
+    assert.strictEqual(stats.hasWarnings(), true);
+    assert.deepStrictEqual(
+      logging(stats).map(({ type }) => type),
+      ["error"],
+    );
+  });
+
+  it("should write an outputReport of what it only logged", async () => {
+    const stats = await pack("full-of-problems", {
+      reportAs: "log",
+      outputReport: { filePath: "report-as-log.txt" },
+    }).runAsync();
+
+    assert.strictEqual(stats.hasErrors(), false);
+    assert.match(
+      readFileSync(
+        join(stats.compilation.compiler.outputPath, "report-as-log.txt"),
+        "utf8",
+      ),
+      /error/u,
+    );
   });
 
   it("should set the severities apart with an object", async () => {
@@ -87,11 +146,18 @@ describe("report as", () => {
   });
 
   it("should let a clean build pass whatever it is set to", async () => {
-    for (const reportAs of ["error", "warning", false, { errors: "warning" }]) {
+    for (const reportAs of [
+      "error",
+      "warning",
+      "log",
+      false,
+      { errors: "warning" },
+    ]) {
       const stats = await pack("good", { reportAs }).runAsync();
 
       assert.strictEqual(stats.hasErrors(), false);
       assert.strictEqual(stats.hasWarnings(), false);
+      assert.deepStrictEqual(logging(stats), []);
     }
   });
 

--- a/test/stylelint/report-as.test.js
+++ b/test/stylelint/report-as.test.js
@@ -42,6 +42,23 @@ describe("report as", () => {
     assert.strictEqual(stats.hasWarnings(), false);
   });
 
+  it("should log rather than report what is set to log", async () => {
+    const compiler = pack("full-of-problems", { reportAs: "log" });
+
+    const stats = await compiler.runAsync();
+
+    assert.strictEqual(stats.hasErrors(), false);
+    assert.strictEqual(stats.hasWarnings(), false);
+
+    const logged = stats.compilation.logging.get("DiagnosticsWebpackPlugin");
+
+    assert.deepStrictEqual(
+      logged.map((/** @type {EXPECTED_ANY} */ entry) => entry.type),
+      ["error", "warn"],
+    );
+    assert.match(logged[0].args[0], /\[stylelint\]/u);
+  });
+
   it("should let a clean build pass whatever it is set to", async () => {
     const compiler = pack("good", { reportAs: "error" });
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -1,6 +1,6 @@
 export type EXPECTED_ANY = any;
 export type Compiler = import("webpack").Compiler;
-export type Severity = "error" | "warning" | false;
+export type Severity = "error" | "warning" | "log" | false;
 export type Results = "errors" | "warnings";
 export type Threads = number | boolean | "auto";
 export type ReportAs =


### PR DESCRIPTION
**Summary**

A check nobody should be stopped by yet had nowhere to go: `"warning"` still puts its results on the compilation, where they count in `stats.hasWarnings()` and a dev server overlays them, and `false` is silence. `reportAs: "log"` writes the same formatted report to webpack's log — the terminal, and `stats.logging` — leaving the compilation carrying neither an error nor a warning. An `outputReport` is written either way, as it is under `false`.

```js
new DiagnosticsPlugin({
  // the whole project is linted, and only the new check is advisory
  checks: [{ use: "eslint" }, { use: "typescript", reportAs: "log" }],
});
```

This is the last of the gaps against the lint integrations for other bundlers; it works per severity like every other value, so `{ errors: "log" }` keeps a check's warnings where they were.

**What kind of change does this PR introduce?**

feat

**Did you add tests for your changes?**

Yes — four cases in `test/report-as.test.js` (logged and not reported, one severity logged while the other is reported, an `outputReport` of what was only logged, and a clean build logging nothing) and one mirrored in `test/stylelint/report-as.test.js`.

**Does this PR introduce a breaking change?**

No — a new value on an existing option.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

Documented in this PR: the `reportAs` type, a row in its table, and what `"log"` is for.

**Use of AI**

Claude Code wrote this change, guided and reviewed by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzZci4NQeiqwdrVfd7dGXy)_